### PR TITLE
fix: ReEDS data center demand mapping to Sienna

### DIFF
--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -410,7 +410,7 @@
       "casefold": true,
       "field": "technology",
       "op": "not_in",
-      "values": ["electrolyzer", "datacenter"]
+      "values": ["electrolyzer", "data-center"]
     },
     "getters": {
       "bus": "get_bus_for_region",

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -557,7 +557,7 @@ def test_consuming_tech_getters(tmp_path) -> None:
     datacenter = ReEDSDataCenterDemand(
         name="DC1",
         region=region,
-        technology="datacenter",
+        technology="data-center",
         capacity=30.0,
         electricity_efficiency=1.0,
         # max_active_power not set — should fall back to capacity

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -637,7 +637,7 @@ def test_reeds_datacenter_demand_translates_to_interruptible_load(tmp_path) -> N
         ReEDSDataCenterDemand(
             name="DC1",
             region=region,
-            technology="datacenter",
+            technology="data-center",
             capacity=200.0,
             electricity_efficiency=1.0,
         )
@@ -652,7 +652,7 @@ def test_reeds_datacenter_demand_translates_to_interruptible_load(tmp_path) -> N
 
     load = loads[0]
     assert load.name == "DC1"
-    assert load.category == "datacenter"
+    assert load.category == "data-center"
     # No explicit max_active_power — falls back to capacity
     assert load.max_active_power.magnitude == pytest.approx(200.0)
     assert load.base_power.magnitude == pytest.approx(200.0)


### PR DESCRIPTION
The reeds-to-sienna generic consuming-technology rule excluded `datacenter` instead of the correct ReEDS identifier `data-center`. This PR corrects the exclusion and updates the existing tests to use the real ReEDS identifier.