### PR TITLE
fix: ReEDS transmission mappings for Sienna and PLEXOS

### DIFF
--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
@@ -442,7 +442,7 @@ def get_battery_capacity(
 
 @getter
 def interface_max_flow(component: ReEDSInterface, context: PluginContext) -> Result[float, ValueError]:
-    """Return the maximum flow for an interface (sum of all lines' max flows)."""
+    """Return the interface forward limit as the sum of member-line forward limits."""
     from r2x_reeds.models import ReEDSTransmissionLine
 
     if context.source_system is None:
@@ -459,15 +459,14 @@ def interface_max_flow(component: ReEDSInterface, context: PluginContext) -> Res
         if line_interface_name == interface_name:
             limits = getattr(line, "max_active_power", None)
             if limits is not None:
-                max_flow = max(limits.from_to, limits.to_from)
-                total_max_flow += float(max_flow)
+                total_max_flow += float(limits.to_from)
 
     return Ok(round(total_max_flow, 1))
 
 
 @getter
 def interface_min_flow(component: ReEDSInterface, context: PluginContext) -> Result[float, ValueError]:
-    """Return the minimum flow for an interface (negative sum of all lines' max flows)."""
+    """Return the interface reverse limit as the negative sum of member-line reverse limits."""
     from r2x_reeds.models import ReEDSTransmissionLine
 
     if context.source_system is None:
@@ -484,8 +483,7 @@ def interface_min_flow(component: ReEDSInterface, context: PluginContext) -> Res
         if line_interface_name == interface_name:
             limits = getattr(line, "max_active_power", None)
             if limits is not None:
-                min_flow = max(abs(limits.from_to), abs(limits.to_from))
-                total_min_flow += float(min_flow)
+                total_min_flow += float(limits.from_to)
 
     return Ok(-round(total_min_flow, 1))
 

--- a/packages/r2x-reeds-to-plexos/tests/test_getters.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_getters.py
@@ -125,7 +125,7 @@ def setup_systems(context):
     interface = ReEDSInterface(name="IFACE1", from_region=region, to_region=region2)
     context.source_system.add_component(interface)
     line = ReEDSTransmissionLine(
-        name="LINE1", interface=interface, max_active_power=FromTo_ToFrom(from_to=100.0, to_from=100.0)
+        name="LINE1", interface=interface, max_active_power=FromTo_ToFrom(from_to=150.0, to_from=100.0)
     )
     context.source_system.add_component(line)
     plexos_line = PLEXOSLine(name="LINE1")
@@ -185,10 +185,10 @@ def test_basic_getters_return_values(tmp_path):
 
     # Interface and line getters
     assert getters.interface_max_flow(objs["interface"], context).unwrap() == 100.0
-    assert getters.interface_min_flow(objs["interface"], context).unwrap() == -100.0
+    assert getters.interface_min_flow(objs["interface"], context).unwrap() == -150.0
     assert getters.get_interface_name(objs["interface"], context).unwrap() == "Z1_Z2-IFACE1"
     assert getters.line_max_flow(objs["line"], context).unwrap() == 100.0
-    assert getters.line_min_flow(objs["line"], context).unwrap() == -100.0
+    assert getters.line_min_flow(objs["line"], context).unwrap() == -150.0
 
     # Storage cost getters
     assert getters.storage_fom_cost_energy(objs["storage"], context).unwrap() == 2.0

--- a/packages/r2x-reeds-to-plexos/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_translation_rule_application.py
@@ -149,7 +149,7 @@ def test_reeds_storage_translates_to_plexos_storage(tmp_path) -> None:
 
 def test_reeds_interface_translates_to_plexos_interface(tmp_path) -> None:
     from r2x_plexos.models import PLEXOSInterface
-    from r2x_reeds.models import ReEDSInterface, ReEDSRegion
+    from r2x_reeds.models import FromTo_ToFrom, ReEDSInterface, ReEDSRegion, ReEDSTransmissionLine
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -157,8 +157,14 @@ def test_reeds_interface_translates_to_plexos_interface(tmp_path) -> None:
     region2 = ReEDSRegion(name="p2", transmission_region="Z2")
     context.source_system.add_component(region1)
     context.source_system.add_component(region2)
+    interface = ReEDSInterface(name="IFACE_1_2", from_region=region1, to_region=region2)
+    context.source_system.add_component(interface)
     context.source_system.add_component(
-        ReEDSInterface(name="IFACE_1_2", from_region=region1, to_region=region2)
+        ReEDSTransmissionLine(
+            name="LINE_1_2",
+            interface=interface,
+            max_active_power=FromTo_ToFrom(from_to=150.0, to_from=100.0),
+        )
     )
     context.target_system = System(name="target", auto_add_composed_components=True)
     context.rules = rules
@@ -171,6 +177,8 @@ def test_reeds_interface_translates_to_plexos_interface(tmp_path) -> None:
     iface = interfaces[0]
     assert iface.name == "Z1_Z2-IFACE_1_2"
     assert iface.category == "reeds-interface"
+    assert iface.max_flow == 100.0
+    assert iface.min_flow == -150.0
 
 
 def test_reeds_reserve_translates_to_plexos_reserve(tmp_path) -> None:

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -351,7 +351,8 @@
       "x": "get_line_reactance",
       "b": "get_line_susceptance",
       "g": "get_line_conductance",
-      "arc": "get_arc_for_line"
+      "arc": "get_arc_for_line",
+      "ext": "get_component_ext"
     },
     "source_type": "ReEDSTransmissionLine",
     "target_type": "MonitoredLine",
@@ -370,8 +371,8 @@
     "filter": {
       "casefold": true,
       "field": "line_type",
-      "op": "eq",
-      "values": ["vsc"]
+      "op": "in",
+      "values": ["vsc", "lcc", "b2b"]
     },
     "getters": {
       "arc": "get_arc_for_line",
@@ -380,7 +381,8 @@
       "active_power_limits_to": "get_hvdc_active_power_limits_to",
       "reactive_power_limits_from": "get_hvdc_reactive_power_limits",
       "reactive_power_limits_to": "get_hvdc_reactive_power_limits",
-      "loss": "get_hvdc_loss"
+      "loss": "get_hvdc_loss",
+      "ext": "get_component_ext"
     },
     "source_type": "ReEDSTransmissionLine",
     "target_type": "TwoTerminalGenericHVDCLine",
@@ -400,7 +402,7 @@
       "casefold": true,
       "field": "line_type",
       "op": "not_in",
-      "values": ["ac", "vsc"],
+      "values": ["ac", "vsc", "lcc", "b2b"],
       "on_missing": "include"
     },
     "getters": {
@@ -414,7 +416,8 @@
       "x": "get_line_reactance",
       "b": "get_line_susceptance",
       "g": "get_line_conductance",
-      "arc": "get_arc_for_line"
+      "arc": "get_arc_for_line",
+      "ext": "get_component_ext"
     },
     "source_type": "ReEDSTransmissionLine",
     "target_type": "Line",

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -358,6 +358,35 @@
     "version": 1
   },
   {
+    "name": "region_hvdc_line",
+    "defaults": {
+      "category": "two-terminal-hvdc-line"
+    },
+    "field_map": {
+      "name": "name",
+      "uuid": "uuid",
+      "category": "category"
+    },
+    "filter": {
+      "casefold": true,
+      "field": "line_type",
+      "op": "eq",
+      "values": ["vsc"]
+    },
+    "getters": {
+      "arc": "get_arc_for_line",
+      "active_power_flow": "get_zero_active_power",
+      "active_power_limits_from": "get_hvdc_active_power_limits_from",
+      "active_power_limits_to": "get_hvdc_active_power_limits_to",
+      "reactive_power_limits_from": "get_hvdc_reactive_power_limits",
+      "reactive_power_limits_to": "get_hvdc_reactive_power_limits",
+      "loss": "get_hvdc_loss"
+    },
+    "source_type": "ReEDSTransmissionLine",
+    "target_type": "TwoTerminalGenericHVDCLine",
+    "version": 1
+  },
+  {
     "name": "region_line",
     "defaults": {
       "category": "line"
@@ -370,8 +399,8 @@
     "filter": {
       "casefold": true,
       "field": "line_type",
-      "op": "neq",
-      "values": ["ac"],
+      "op": "not_in",
+      "values": ["ac", "vsc"],
       "on_missing": "include"
     },
     "getters": {

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -326,6 +326,38 @@
     "version": 1
   },
   {
+    "name": "region_monitored_line",
+    "defaults": {
+      "category": "monitored-line"
+    },
+    "field_map": {
+      "name": "name",
+      "uuid": "uuid",
+      "category": "category"
+    },
+    "filter": {
+      "casefold": true,
+      "field": "line_type",
+      "op": "eq",
+      "values": ["ac"]
+    },
+    "getters": {
+      "rating": "get_monitored_line_rating",
+      "active_power_flow": "get_zero_active_power",
+      "reactive_power_flow": "get_line_reactive_power_flow",
+      "flow_limits": "get_line_flow_limits",
+      "angle_limits": "get_line_angle_limits",
+      "r": "get_line_resistance",
+      "x": "get_line_reactance",
+      "b": "get_line_susceptance",
+      "g": "get_line_conductance",
+      "arc": "get_arc_for_line"
+    },
+    "source_type": "ReEDSTransmissionLine",
+    "target_type": "MonitoredLine",
+    "version": 1
+  },
+  {
     "name": "region_line",
     "defaults": {
       "category": "line"
@@ -334,6 +366,13 @@
       "name": "name",
       "uuid": "uuid",
       "category": "category"
+    },
+    "filter": {
+      "casefold": true,
+      "field": "line_type",
+      "op": "neq",
+      "values": ["ac"],
+      "on_missing": "include"
     },
     "getters": {
       "rating": "get_line_rating",

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -184,6 +184,36 @@ def get_line_rating(component: ReEDSTransmissionLine, context: PluginContext):
 
 
 @getter
+def get_monitored_line_rating(component: ReEDSTransmissionLine, context: PluginContext):
+    """Use the larger directional limit as the line rating."""
+    try:
+        return Ok(max(component.max_active_power.from_to, component.max_active_power.to_from))
+    except Exception as e:
+        return Err(ValueError(f"Could not get line rating: {e}"))
+
+
+@getter
+def get_line_flow_limits(
+    component: ReEDSTransmissionLine, context: PluginContext
+) -> Result[FromTo_ToFrom, ValueError]:
+    """Map ReEDS directional capacities to Sienna flow limits.
+
+    ReEDS transmission parsing stores the source ``r -> rr`` capacity in
+    ``max_active_power.to_from`` and the reverse capacity in
+    ``max_active_power.from_to``.
+    """
+    try:
+        return Ok(
+            FromTo_ToFrom(
+                from_to=component.max_active_power.to_from,
+                to_from=component.max_active_power.from_to,
+            )
+        )
+    except Exception as e:
+        return Err(ValueError(f"Could not get line flow limits: {e}"))
+
+
+@getter
 def get_line_active_power_flow(component: ReEDSTransmissionLine, context: PluginContext):
     """Use max_active_power.from_to as the active power flow."""
     try:

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -214,6 +214,46 @@ def get_line_flow_limits(
 
 
 @getter
+def get_hvdc_active_power_limits_from(
+    component: ReEDSTransmissionLine, context: PluginContext
+) -> Result[MinMax, ValueError]:
+    """Map directional ReEDS capacities to the HVDC from-terminal limits."""
+    try:
+        forward = component.max_active_power.to_from
+        backward = component.max_active_power.from_to
+        return Ok(MinMax(min=-backward, max=forward))
+    except Exception as e:
+        return Err(ValueError(f"Could not get HVDC from-terminal limits: {e}"))
+
+
+@getter
+def get_hvdc_active_power_limits_to(
+    component: ReEDSTransmissionLine, context: PluginContext
+) -> Result[MinMax, ValueError]:
+    """Map directional ReEDS capacities to the HVDC to-terminal limits."""
+    try:
+        forward = component.max_active_power.to_from
+        backward = component.max_active_power.from_to
+        return Ok(MinMax(min=-forward, max=backward))
+    except Exception as e:
+        return Err(ValueError(f"Could not get HVDC to-terminal limits: {e}"))
+
+
+@getter
+def get_hvdc_reactive_power_limits(
+    component: ReEDSTransmissionLine, context: PluginContext
+) -> Result[MinMax, ValueError]:
+    """Use zero reactive power limits because ReEDS does not provide them."""
+    return Ok(MinMax(min=0.0, max=0.0))
+
+
+@getter
+def get_hvdc_loss(component: ReEDSTransmissionLine, context: PluginContext):
+    """Represent the ReEDS transmission loss fraction as a linear loss curve."""
+    return Ok(LinearCurve(float(component.losses or 0.0)))
+
+
+@getter
 def get_line_active_power_flow(component: ReEDSTransmissionLine, context: PluginContext):
     """Use max_active_power.from_to as the active power flow."""
     try:

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -92,7 +92,10 @@ def _lookup_area(context: PluginContext, name: str | None) -> Area | None:
 
 @getter
 def get_component_ext(component: object, context: PluginContext) -> Result[dict, ValueError]:
-    """Return source metadata that must survive in the target component's ext dict."""
+    """
+    Get the component's ext dict, storing the technology name under the 'technology' key
+    and the ReEDS line type under the 'reeds_line_type' key.
+    """
     ext = getattr(component, "ext", None)
     if ext is None:
         ext = {}

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -92,19 +92,21 @@ def _lookup_area(context: PluginContext, name: str | None) -> Area | None:
 
 @getter
 def get_component_ext(component: object, context: PluginContext) -> Result[dict, ValueError]:
-    """
-    Get the component's ext dict, storing the technology name under the 'technology' key.
-    """
+    """Return source metadata that must survive in the target component's ext dict."""
     ext = getattr(component, "ext", None)
     if ext is None:
         ext = {}
     elif not isinstance(ext, dict):
         return Err(ValueError("Component ext attribute is not a dict"))
 
+    ext = dict(ext)
     technology = getattr(component, "technology", None)
     if technology is not None:
-        ext = dict(ext)
         ext["technology"] = technology
+
+    line_type = getattr(component, "line_type", None)
+    if line_type is not None:
+        ext["reeds_line_type"] = line_type
 
     return Ok(ext)
 

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -131,6 +131,15 @@ def test_basic_getters_return_values(tmp_path) -> None:
     )
     context.source_system.add_component(line)
 
+    hvdc_line = ReEDSTransmissionLine(
+        name="p1_p2_vsc",
+        interface=interface,
+        max_active_power={"from_to": 80.0, "to_from": 100.0},
+        losses=0.03,
+        line_type="vsc",
+    )
+    context.source_system.add_component(hvdc_line)
+
     # Test thermal generator getters
     assert getters.unique_component_name(thermal, context).unwrap() == "p1_THERM"
     assert getters.get_capacity_as_rating(thermal, context).unwrap() == 10.0
@@ -171,6 +180,17 @@ def test_basic_getters_return_values(tmp_path) -> None:
     assert getters.get_monitored_line_rating(line, context).unwrap() == 100.0
     assert getters.get_line_flow_limits(line, context).unwrap().from_to == 100.0
     assert getters.get_line_flow_limits(line, context).unwrap().to_from == 100.0
+
+    hvdc_limits_from = getters.get_hvdc_active_power_limits_from(hvdc_line, context).unwrap()
+    assert hvdc_limits_from.min == -80.0
+    assert hvdc_limits_from.max == 100.0
+    hvdc_limits_to = getters.get_hvdc_active_power_limits_to(hvdc_line, context).unwrap()
+    assert hvdc_limits_to.min == -100.0
+    assert hvdc_limits_to.max == 80.0
+    reactive_limits = getters.get_hvdc_reactive_power_limits(hvdc_line, context).unwrap()
+    assert reactive_limits.min == 0.0
+    assert reactive_limits.max == 0.0
+    assert getters.get_hvdc_loss(hvdc_line, context).unwrap().function_data.proportional_term == 0.03
 
     # Test hydro getters
     assert getters.hydro_rating(hydro, context).unwrap() == 8.0

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -167,6 +167,11 @@ def test_basic_getters_return_values(tmp_path) -> None:
     assert getters.demand_max_reactive_power(demand, context).unwrap() == 0.0
     assert getters.get_load_base_power(demand, context).unwrap() == 100.0
 
+    # Test transmission line getters
+    assert getters.get_monitored_line_rating(line, context).unwrap() == 100.0
+    assert getters.get_line_flow_limits(line, context).unwrap().from_to == 100.0
+    assert getters.get_line_flow_limits(line, context).unwrap().to_from == 100.0
+
     # Test hydro getters
     assert getters.hydro_rating(hydro, context).unwrap() == 8.0
     assert getters.hydro_operation_cost(hydro, context).unwrap() is not None

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -127,6 +127,14 @@ def test_has_transmission_line_rule() -> None:
         for rule in rules_data
     ), "Missing AC ReEDSTransmissionLine -> MonitoredLine rule"
 
+    assert any(
+        rule.get("source_type") == "ReEDSTransmissionLine"
+        and rule.get("target_type") == "TwoTerminalGenericHVDCLine"
+        and rule.get("filter", {}).get("field") == "line_type"
+        and rule.get("filter", {}).get("values") == ["vsc"]
+        for rule in rules_data
+    ), "Missing VSC ReEDSTransmissionLine -> TwoTerminalGenericHVDCLine rule"
+
 
 def test_rules_have_required_fields() -> None:
     """Verify all rules have essential structure."""

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -115,7 +115,7 @@ def test_has_demand_rule() -> None:
 
 
 def test_has_transmission_line_rule() -> None:
-    """Verify AC ReEDSTransmissionLine maps to MonitoredLine."""
+    """Verify ReEDS transmission types map to the corresponding Sienna types."""
     rules_path = files("r2x_reeds_to_sienna.config") / "rules.json"
     rules_data = json.loads(rules_path.read_text())
 
@@ -131,9 +131,10 @@ def test_has_transmission_line_rule() -> None:
         rule.get("source_type") == "ReEDSTransmissionLine"
         and rule.get("target_type") == "TwoTerminalGenericHVDCLine"
         and rule.get("filter", {}).get("field") == "line_type"
-        and rule.get("filter", {}).get("values") == ["vsc"]
+        and rule.get("filter", {}).get("op") == "in"
+        and rule.get("filter", {}).get("values") == ["vsc", "lcc", "b2b"]
         for rule in rules_data
-    ), "Missing VSC ReEDSTransmissionLine -> TwoTerminalGenericHVDCLine rule"
+    ), "Missing ReEDS VSC/LCC/B2B transmission -> TwoTerminalGenericHVDCLine rule"
 
 
 def test_rules_have_required_fields() -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -115,14 +115,17 @@ def test_has_demand_rule() -> None:
 
 
 def test_has_transmission_line_rule() -> None:
-    """Verify ReEDSTransmissionLine maps to Line."""
+    """Verify AC ReEDSTransmissionLine maps to MonitoredLine."""
     rules_path = files("r2x_reeds_to_sienna.config") / "rules.json"
     rules_data = json.loads(rules_path.read_text())
 
     assert any(
-        rule.get("source_type") == "ReEDSTransmissionLine" and rule.get("target_type") == "Line"
+        rule.get("source_type") == "ReEDSTransmissionLine"
+        and rule.get("target_type") == "MonitoredLine"
+        and rule.get("filter", {}).get("field") == "line_type"
+        and rule.get("filter", {}).get("values") == ["ac"]
         for rule in rules_data
-    ), "Missing ReEDSTransmissionLine -> Line rule"
+    ), "Missing AC ReEDSTransmissionLine -> MonitoredLine rule"
 
 
 def test_rules_have_required_fields() -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -336,9 +336,9 @@ def test_reeds_reserve_translates_to_variable_reserve(tmp_path) -> None:
     assert reserve.deployed_fraction == 1.0
 
 
-def test_reeds_transmission_line_translates_to_line(tmp_path) -> None:
+def test_reeds_ac_transmission_line_translates_to_monitored_line(tmp_path) -> None:
     from r2x_reeds.models import ReEDSInterface, ReEDSRegion, ReEDSTransmissionLine
-    from r2x_sienna.models import Line
+    from r2x_sienna.models import MonitoredLine
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -350,7 +350,10 @@ def test_reeds_transmission_line_translates_to_line(tmp_path) -> None:
     context.source_system.add_component(interface)
     context.source_system.add_component(
         ReEDSTransmissionLine(
-            name="LINE_1_2", interface=interface, max_active_power={"from_to": 150.0, "to_from": 150.0}
+            name="LINE_1_2",
+            interface=interface,
+            line_type="ac",
+            max_active_power={"from_to": 125.0, "to_from": 150.0},
         )
     )
     context.target_system = System(name="target", auto_add_composed_components=True)
@@ -359,12 +362,17 @@ def test_reeds_transmission_line_translates_to_line(tmp_path) -> None:
     result = apply_rules_to_context(context)
     assert result.total_rules > 0
 
-    lines = list(context.target_system.get_components(Line))
+    lines = list(context.target_system.get_components(MonitoredLine))
     assert len(lines) == 1
 
     line = lines[0]
     assert line.name == "LINE_1_2"
     assert line.rating == 150.0
+    assert line.flow_limits.from_to == 150.0
+    assert line.flow_limits.to_from == 125.0
+    assert line.active_power_flow == 0.0
+    assert line.rating_b is None
+    assert line.rating_c is None
     assert line.r == 0.0
     assert line.x == 0.0
     assert line.angle_limits.min == -90.0

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -378,9 +378,10 @@ def test_reeds_ac_transmission_line_translates_to_monitored_line(tmp_path) -> No
     assert line.angle_limits.min == -90.0
     assert line.angle_limits.max == 90.0
     assert line.arc is not None
+    assert line.ext == {"reeds_line_type": "ac"}
 
 
-def test_reeds_vsc_transmission_line_translates_to_generic_hvdc_line(tmp_path) -> None:
+def test_reeds_vsc_lcc_b2b_transmission_types_translate_to_generic_hvdc_lines(tmp_path) -> None:
     from r2x_reeds.models import ReEDSInterface, ReEDSRegion, ReEDSTransmissionLine
     from r2x_sienna.models import Line, TwoTerminalGenericHVDCLine
 
@@ -392,15 +393,20 @@ def test_reeds_vsc_transmission_line_translates_to_generic_hvdc_line(tmp_path) -
     context.source_system.add_component(region2)
     interface = ReEDSInterface(name="IFACE", from_region=region1, to_region=region2)
     context.source_system.add_component(interface)
-    context.source_system.add_component(
-        ReEDSTransmissionLine(
-            name="VSC_1_2",
-            interface=interface,
-            line_type="vsc",
-            losses=0.025,
-            max_active_power={"from_to": 125.0, "to_from": 150.0},
+    source_lines = {
+        "VSC_1_2": {"line_type": "vsc", "losses": 0.025},
+        "LCC_1_2": {"line_type": "lcc", "losses": 0.015},
+        "B2B_1_2": {"line_type": "b2b", "losses": 0.010},
+    }
+    for name, attributes in source_lines.items():
+        context.source_system.add_component(
+            ReEDSTransmissionLine(
+                name=name,
+                interface=interface,
+                max_active_power={"from_to": 125.0, "to_from": 150.0},
+                **attributes,
+            )
         )
-    )
     context.target_system = System(name="target", auto_add_composed_components=True)
     context.rules = rules
 
@@ -408,23 +414,26 @@ def test_reeds_vsc_transmission_line_translates_to_generic_hvdc_line(tmp_path) -
     assert result.total_rules > 0
 
     lines = list(context.target_system.get_components(TwoTerminalGenericHVDCLine))
-    assert len(lines) == 1
+    assert len(lines) == 3
     assert list(context.target_system.get_components(Line)) == []
 
-    line = lines[0]
-    assert line.name == "VSC_1_2"
-    assert line.active_power_flow == 0.0
-    assert line.active_power_limits_from.min == -125.0
-    assert line.active_power_limits_from.max == 150.0
-    assert line.active_power_limits_to.min == -150.0
-    assert line.active_power_limits_to.max == 125.0
-    assert line.reactive_power_limits_from.min == 0.0
-    assert line.reactive_power_limits_from.max == 0.0
-    assert line.reactive_power_limits_to.min == 0.0
-    assert line.reactive_power_limits_to.max == 0.0
-    assert line.loss.function_data.proportional_term == 0.025
-    assert line.loss.function_data.constant_term == 0.0
-    assert line.arc is not None
+    lines_by_name = {line.name: line for line in lines}
+    assert lines_by_name.keys() == source_lines.keys()
+    for name, attributes in source_lines.items():
+        line = lines_by_name[name]
+        assert line.active_power_flow == 0.0
+        assert line.active_power_limits_from.min == -125.0
+        assert line.active_power_limits_from.max == 150.0
+        assert line.active_power_limits_to.min == -150.0
+        assert line.active_power_limits_to.max == 125.0
+        assert line.reactive_power_limits_from.min == 0.0
+        assert line.reactive_power_limits_from.max == 0.0
+        assert line.reactive_power_limits_to.min == 0.0
+        assert line.reactive_power_limits_to.max == 0.0
+        assert line.loss.function_data.proportional_term == attributes["losses"]
+        assert line.loss.function_data.constant_term == 0.0
+        assert line.arc is not None
+        assert line.ext == {"reeds_line_type": attributes["line_type"]}
 
 
 def test_multiple_regions_create_multiple_buses_and_areas(tmp_path) -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -380,6 +380,53 @@ def test_reeds_ac_transmission_line_translates_to_monitored_line(tmp_path) -> No
     assert line.arc is not None
 
 
+def test_reeds_vsc_transmission_line_translates_to_generic_hvdc_line(tmp_path) -> None:
+    from r2x_reeds.models import ReEDSInterface, ReEDSRegion, ReEDSTransmissionLine
+    from r2x_sienna.models import Line, TwoTerminalGenericHVDCLine
+
+    context, rules = make_context_and_rules(tmp_path)
+    context.source_system = System(name="source", auto_add_composed_components=True)
+    region1 = ReEDSRegion(name="p1", category="region")
+    region2 = ReEDSRegion(name="p2", category="region")
+    context.source_system.add_component(region1)
+    context.source_system.add_component(region2)
+    interface = ReEDSInterface(name="IFACE", from_region=region1, to_region=region2)
+    context.source_system.add_component(interface)
+    context.source_system.add_component(
+        ReEDSTransmissionLine(
+            name="VSC_1_2",
+            interface=interface,
+            line_type="vsc",
+            losses=0.025,
+            max_active_power={"from_to": 125.0, "to_from": 150.0},
+        )
+    )
+    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.rules = rules
+
+    result = apply_rules_to_context(context)
+    assert result.total_rules > 0
+
+    lines = list(context.target_system.get_components(TwoTerminalGenericHVDCLine))
+    assert len(lines) == 1
+    assert list(context.target_system.get_components(Line)) == []
+
+    line = lines[0]
+    assert line.name == "VSC_1_2"
+    assert line.active_power_flow == 0.0
+    assert line.active_power_limits_from.min == -125.0
+    assert line.active_power_limits_from.max == 150.0
+    assert line.active_power_limits_to.min == -150.0
+    assert line.active_power_limits_to.max == 125.0
+    assert line.reactive_power_limits_from.min == 0.0
+    assert line.reactive_power_limits_from.max == 0.0
+    assert line.reactive_power_limits_to.min == 0.0
+    assert line.reactive_power_limits_to.max == 0.0
+    assert line.loss.function_data.proportional_term == 0.025
+    assert line.loss.function_data.constant_term == 0.0
+    assert line.arc is not None
+
+
 def test_multiple_regions_create_multiple_buses_and_areas(tmp_path) -> None:
     from r2x_reeds.models import ReEDSRegion
     from r2x_sienna.models import ACBus, Area


### PR DESCRIPTION
## Sienna
ReEDS transmission corridors can have different forward and reverse transfer capacities. Previously Sienna transmission components did not preserve these directional limits.

This PR maps AC corridors to `MonitoredLine` components with directional flow limits. VSC, LCC and B2B corridors are mapped to `TwoTerminalGenericHVDCLine` components with signed terminal limits and proportional transmission losses.

| ReEDS  | Sienna |
|---|---|
| `AC` | `MonitoredLine` |
| `VSC` | `TwoTerminalGenericHVDCLine` |
| `LCC` | `TwoTerminalGenericHVDCLine` |
| `B2B` | `TwoTerminalGenericHVDCLine` |

## PLEXOS
PLEXOS interfaces previously assigned the larger directional capacity to both `Max Flow` and `Min Flow` properties. This produced symmetric positive bounds and lost the ReEDS flow direction.

This PR calculates each interface bound from its member lines. `Max Flow` uses the summed forward capacity while `Min Flow` uses the negative summed reverse capacity.