### PR TITLE
fix: ReEDS storage efficiency mapping in PLEXOS and Sienna

### DIFF
--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
@@ -336,30 +336,26 @@ def maintenance_rate_percent(component: object, context: PluginContext) -> Resul
 def charge_efficiency_percent(
     component: ReEDSGenerator | ReEDSStorage, context: PluginContext
 ) -> Result[float, ValueError]:
-    """Convert charge efficiency (0-1) to percent for PLEXOS, using defaults if missing."""
-    gen_technology = getattr(component, "technology", "")
-    efficiency = getattr(component, "charge_efficiency", None)
+    """Apply ReEDS round-trip efficiency to charging as a PLEXOS percentage."""
+    efficiency = getattr(component, "round_trip_efficiency", None)
+    if efficiency is not None and efficiency != 0.0:
+        return Ok(float(efficiency) * 100.0)
 
-    if efficiency is not None:
-        return Ok(_float_or_zero(efficiency) * 100.0)
-
-    default_efficiency = _get_defaults(gen_technology, "charge_efficiency")
-    return Ok(float(default_efficiency) * 100.0)
+    technology = getattr(component, "technology", "")
+    return Ok(_get_defaults(technology, "charge_efficiency") * 100.0)
 
 
 @getter
 def discharge_efficiency_percent(
     component: ReEDSGenerator | ReEDSStorage, context: PluginContext
 ) -> Result[float, ValueError]:
-    """Convert discharge efficiency (0-1) to percent for PLEXOS, using defaults if missing."""
-    gen_technology = getattr(component, "technology", "")
+    """Use lossless discharging to match the ReEDS storage-level equation."""
     efficiency = getattr(component, "round_trip_efficiency", None)
-
     if efficiency is not None and efficiency != 0.0:
-        return Ok(_float_or_zero(efficiency) * 100.0)
+        return Ok(100.0)
 
-    default_efficiency = _get_defaults(gen_technology, "discharge_efficiency")
-    return Ok(float(default_efficiency) * 100.0)
+    technology = getattr(component, "technology", "")
+    return Ok(_get_defaults(technology, "discharge_efficiency") * 100.0)
 
 
 @getter

--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
@@ -336,13 +336,15 @@ def maintenance_rate_percent(component: object, context: PluginContext) -> Resul
 def charge_efficiency_percent(
     component: ReEDSGenerator | ReEDSStorage, context: PluginContext
 ) -> Result[float, ValueError]:
-    """Apply ReEDS round-trip efficiency to charging as a PLEXOS percentage."""
+    """Convert charge efficiency (0-1) to percent for PLEXOS, using defaults if missing."""
+    gen_technology = getattr(component, "technology", "")
     efficiency = getattr(component, "round_trip_efficiency", None)
-    if efficiency is not None and efficiency != 0.0:
-        return Ok(float(efficiency) * 100.0)
 
-    technology = getattr(component, "technology", "")
-    return Ok(_get_defaults(technology, "charge_efficiency") * 100.0)
+    if efficiency is not None and efficiency != 0.0:
+        return Ok(_float_or_zero(efficiency) * 100.0)
+
+    default_efficiency = _get_defaults(gen_technology, "charge_efficiency")
+    return Ok(float(default_efficiency) * 100.0)
 
 
 @getter
@@ -350,12 +352,7 @@ def discharge_efficiency_percent(
     component: ReEDSGenerator | ReEDSStorage, context: PluginContext
 ) -> Result[float, ValueError]:
     """Use lossless discharging to match the ReEDS storage-level equation."""
-    efficiency = getattr(component, "round_trip_efficiency", None)
-    if efficiency is not None and efficiency != 0.0:
-        return Ok(100.0)
-
-    technology = getattr(component, "technology", "")
-    return Ok(_get_defaults(technology, "discharge_efficiency") * 100.0)
+    return Ok(100.0)
 
 
 @getter

--- a/packages/r2x-reeds-to-plexos/tests/test_getters.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_getters.py
@@ -177,7 +177,7 @@ def test_basic_getters_return_values(tmp_path):
     assert getters.forced_outage_rate_percent(objs["thermal"], context).unwrap() == 2.0
     assert getters.maintenance_rate_percent(objs["thermal"], context).unwrap() == 0.0
     assert getters.charge_efficiency_percent(objs["storage"], context).unwrap() == 95.0
-    assert getters.discharge_efficiency_percent(objs["storage"], context).unwrap() == 95.0
+    assert getters.discharge_efficiency_percent(objs["storage"], context).unwrap() == 100.0
     assert getters.mean_time_to_repair_hours(objs["thermal"], context).unwrap() == 0.0
     assert getters.get_battery_max_soc(objs["storage"], context).unwrap() == 100.0
     assert getters.get_battery_initial_soc(objs["storage"], context).unwrap() == 50.0

--- a/packages/r2x-reeds-to-plexos/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_translation_rule_application.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from importlib.resources import files
 
 from r2x_core import DataStore, PluginConfig, PluginContext, Rule, System, apply_rules_to_context
@@ -143,8 +144,18 @@ def test_reeds_storage_translates_to_plexos_storage(tmp_path) -> None:
     ):
         if cls is not None:
             storages.extend(list(context.target_system.get_components(cls)))
-    storage = [s for s in storages if s.name in ("BATT1", "BATT1_head", "BATT1_tail")]
-    assert storage
+    translated_storage = [
+        component for component in storages if component.name in ("BATT1", "BATT1_head", "BATT1_tail")
+    ]
+    assert translated_storage
+
+    battery = next(context.target_system.get_components(PLEXOSBattery))
+    assert battery.charge_efficiency == storage.round_trip_efficiency * 100.0
+    assert battery.discharge_efficiency == 100.0
+    assert math.isclose(
+        battery.charge_efficiency * battery.discharge_efficiency / 10_000.0,
+        storage.round_trip_efficiency,
+    )
 
 
 def test_reeds_interface_translates_to_plexos_interface(tmp_path) -> None:

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -872,7 +872,8 @@ def storage_power_limits(component: ReEDSStorage, context: PluginContext) -> Res
 @getter
 def storage_efficiency(component: ReEDSStorage, context: PluginContext) -> Result[InputOutput, ValueError]:
     """Apply ReEDS storage losses to charging and use lossless discharging."""
-    default_eff = 0.95
+    technology = getattr(component, "technology", "")
+    default_eff = _get_defaults(technology, "charge_efficiency")
     rte = float(getattr(component, "round_trip_efficiency", default_eff) or default_eff)
     return Ok(InputOutput(input=rte, output=1.0))
 

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -871,17 +871,10 @@ def storage_power_limits(component: ReEDSStorage, context: PluginContext) -> Res
 
 @getter
 def storage_efficiency(component: ReEDSStorage, context: PluginContext) -> Result[InputOutput, ValueError]:
-    """Map round-trip efficiency to symmetric input/output pair.
-
-    Splits the round-trip efficiency as sqrt(rte) for both charge and discharge,
-    so input * output = rte.
-    """
-    import math
-
+    """Apply ReEDS storage losses to charging and use lossless discharging."""
     default_eff = 0.95
     rte = float(getattr(component, "round_trip_efficiency", default_eff) or default_eff)
-    one_side = math.sqrt(max(rte, 0.0))
-    return Ok(InputOutput(input=one_side, output=one_side))
+    return Ok(InputOutput(input=rte, output=1.0))
 
 
 @getter

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -189,6 +189,11 @@ def test_basic_getters_return_values(tmp_path) -> None:
     efficiency = getters.storage_efficiency(storage, context).unwrap()
     assert efficiency.input == pytest.approx(0.9)
     assert efficiency.output == pytest.approx(1.0)
+    default_efficiency = getters.storage_efficiency(
+        storage.model_copy(update={"round_trip_efficiency": 0.0}), context
+    ).unwrap()
+    assert default_efficiency.input == pytest.approx(0.95)
+    assert default_efficiency.output == pytest.approx(1.0)
     assert getters.storage_tech(storage, context).unwrap() == StorageTechs.LIB
     assert getters.storage_prime_mover(storage, context).unwrap() == PrimeMoversType.ES
     assert getters.storage_initial_level(storage, context).unwrap() == 0.0

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
 import pytest
 from infrasys.cost_curves import FuelCurve, LinearCurve
 from r2x_reeds.models import (
@@ -189,8 +187,8 @@ def test_basic_getters_return_values(tmp_path) -> None:
     power_limits = getters.storage_power_limits(storage, context).unwrap()
     assert power_limits.max == 4.0
     efficiency = getters.storage_efficiency(storage, context).unwrap()
-    assert efficiency.output == pytest.approx(math.sqrt(0.9))  # sqrt(rte)
-    assert efficiency.input == pytest.approx(math.sqrt(0.9))  # symmetric
+    assert efficiency.input == pytest.approx(0.9)
+    assert efficiency.output == pytest.approx(1.0)
     assert getters.storage_tech(storage, context).unwrap() == StorageTechs.LIB
     assert getters.storage_prime_mover(storage, context).unwrap() == PrimeMoversType.ES
     assert getters.storage_initial_level(storage, context).unwrap() == 0.0

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import math
 from importlib.resources import files
 
 import pytest
@@ -241,7 +240,8 @@ def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:
     assert storage.category == "battery_4"
     assert storage.rating == 50.0
     assert storage.storage_capacity == 200.0  # 50 * 4
-    assert storage.efficiency.output == pytest.approx(math.sqrt(0.85))  # sqrt(rte)
+    assert storage.efficiency.input == pytest.approx(0.85)
+    assert storage.efficiency.output == pytest.approx(1.0)
 
 
 def test_reeds_demand_translates_to_power_load(tmp_path) -> None:


### PR DESCRIPTION
`r2x-reeds-to-plexos` previously combined its default 95% charging efficiency with the ReEDS round-trip efficiency as the discharging efficiency. For a ReEDS efficiency of 85%, this produced an effective round-trip efficiency of 80.75% in the translated PLEXOS db.

ReEDS applies its storage efficiency entirely while charging and assumes lossless discharging. This PR implements that representation. As a result, PLEXOS now uses the ReEDS round-trip efficiency for charging and 100% for discharging. Sienna similarly maps it to the input efficiency and uses 1.0 for the output efficiency.
