### PR TITLE
fix: ReEDS pumped hydro mapping and hydro operating costs

### DIFF
--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/config/rules.json
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/config/rules.json
@@ -372,6 +372,7 @@
       "min_stable_level": "min_stable_level_mw",
       "pump_efficiency": "get_generator_pump_efficiency_percent",
       "pump_load": "get_generator_pump_load_mw",
+      "vom_charge": "storage_vom_cost_energy",
       "commit": "get_commitment_status"
     },
     "source_type": "ReEDSStorage",

--- a/packages/r2x-reeds-to-plexos/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_translation_rule_application.py
@@ -158,6 +158,38 @@ def test_reeds_storage_translates_to_plexos_storage(tmp_path) -> None:
     )
 
 
+def test_reeds_pumped_hydro_vom_translates_to_plexos(tmp_path) -> None:
+    from r2x_plexos.models import PLEXOSGenerator
+    from r2x_reeds.models import ReEDSRegion, ReEDSStorage
+
+    context, rules = make_context_and_rules(tmp_path)
+    context.source_system = System(name="source", auto_add_composed_components=True)
+    region = ReEDSRegion(name="p1", transmission_region="Z1")
+    context.source_system.add_component(region)
+    context.source_system.add_component(
+        ReEDSStorage(
+            name="PUMPED_HYDRO1",
+            region=region,
+            technology="pumped-hydro",
+            capacity=50.0,
+            storage_duration=12.0,
+            round_trip_efficiency=0.8,
+            vom_cost=0.38,
+        )
+    )
+    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.rules = rules
+
+    result = apply_rules_to_context(context)
+    assert result.total_rules > 0
+
+    generators = list(context.target_system.get_components(PLEXOSGenerator))
+    assert len(generators) == 1
+    generator = generators[0]
+    assert generator.name == "PUMPED_HYDRO1"
+    assert generator.vom_charge == 0.38
+
+
 def test_reeds_interface_translates_to_plexos_interface(tmp_path) -> None:
     from r2x_plexos.models import PLEXOSInterface
     from r2x_reeds.models import FromTo_ToFrom, ReEDSInterface, ReEDSRegion, ReEDSTransmissionLine

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -321,6 +321,7 @@
     },
     "getters": {
       "bus": "get_bus_for_region",
+      "services": "get_gen_services",
       "rating": "storage_rating",
       "base_power": "storage_rating",
       "active_power_limits": "storage_power_limits",
@@ -337,7 +338,7 @@
         "pumped-hydro"
       ]
     },
-    "depends_on": ["region_bus"],
+    "depends_on": ["region_bus", "variable_reserve"],
     "source_type": "ReEDSStorage",
     "target_type": "HydroPumpTurbine",
     "version": 1

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -276,9 +276,136 @@
       "reactive_power": "get_zero_reactive_power",
       "ext": "get_component_ext"
     },
+    "filter": {
+      "casefold": true,
+      "field": "technology",
+      "op": "not_in",
+      "values": [
+        "pumped-hydro"
+      ]
+    },
     "depends_on": ["region_bus", "variable_reserve"],
     "source_type": "ReEDSStorage",
     "target_type": "EnergyReservoirStorage",
+    "version": 1
+  },
+  {
+    "name": "pumped_hydro_turbine",
+    "defaults": {
+      "category": "pumped-hydro",
+      "active_power": 0.0,
+      "reactive_power": 0.0,
+      "reactive_power_limits": null,
+      "outflow_limits": null,
+      "powerhouse_elevation": 0.0,
+      "ramp_limits": null,
+      "time_limits": null,
+      "active_power_pump": 0.0,
+      "transition_time": {
+        "turbine": 0.0,
+        "pump": 0.0
+      },
+      "minimum_time": {
+        "turbine": 0.0,
+        "pump": 0.0
+      },
+      "travel_time": null,
+      "conversion_factor": 1.0,
+      "must_run": false,
+      "prime_mover_type": "PS"
+    },
+    "field_map": {
+      "name": "name",
+      "uuid": "uuid",
+      "category": "technology"
+    },
+    "getters": {
+      "bus": "get_bus_for_region",
+      "rating": "storage_rating",
+      "base_power": "storage_rating",
+      "active_power_limits": "storage_power_limits",
+      "active_power_limits_pump": "storage_power_limits",
+      "efficiency": "pumped_hydro_efficiency",
+      "operation_cost": "pumped_hydro_operation_cost",
+      "ext": "get_component_ext"
+    },
+    "filter": {
+      "casefold": true,
+      "field": "technology",
+      "op": "in",
+      "values": [
+        "pumped-hydro"
+      ]
+    },
+    "depends_on": ["region_bus"],
+    "source_type": "ReEDSStorage",
+    "target_type": "HydroPumpTurbine",
+    "version": 1
+  },
+  {
+    "name": "pumped_hydro_head_reservoir",
+    "defaults": {
+      "category": "head",
+      "initial_level": 0.5,
+      "spillage_limits": null,
+      "inflow": 0.0,
+      "outflow": 0.0,
+      "level_targets": null,
+      "intake_elevation": 0.0,
+      "level_data_type": "ENERGY",
+      "reservoir_location": "HEAD"
+    },
+    "getters": {
+      "name": "pumped_hydro_head_name",
+      "storage_level_limits": "pumped_hydro_storage_level_limits",
+      "operation_cost": "hydro_reservoir_operation_cost",
+      "downstream_turbines": "get_pumped_hydro_turbine",
+      "ext": "get_component_ext"
+    },
+    "filter": {
+      "casefold": true,
+      "field": "technology",
+      "op": "in",
+      "values": [
+        "pumped-hydro"
+      ]
+    },
+    "depends_on": ["pumped_hydro_turbine"],
+    "source_type": "ReEDSStorage",
+    "target_type": "HydroReservoir",
+    "version": 1
+  },
+  {
+    "name": "pumped_hydro_tail_reservoir",
+    "defaults": {
+      "category": "tail",
+      "initial_level": 0.5,
+      "spillage_limits": null,
+      "inflow": 0.0,
+      "outflow": 0.0,
+      "level_targets": null,
+      "intake_elevation": 0.0,
+      "level_data_type": "ENERGY",
+      "reservoir_location": "TAIL"
+    },
+    "getters": {
+      "name": "pumped_hydro_tail_name",
+      "storage_level_limits": "pumped_hydro_storage_level_limits",
+      "operation_cost": "hydro_reservoir_operation_cost",
+      "upstream_turbines": "get_pumped_hydro_turbine",
+      "ext": "get_component_ext"
+    },
+    "filter": {
+      "casefold": true,
+      "field": "technology",
+      "op": "in",
+      "values": [
+        "pumped-hydro"
+      ]
+    },
+    "depends_on": ["pumped_hydro_turbine"],
+    "source_type": "ReEDSStorage",
+    "target_type": "HydroReservoir",
     "version": 1
   },
   {

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -328,7 +328,7 @@
       "active_power_limits_pump": "storage_power_limits",
       "efficiency": "pumped_hydro_efficiency",
       "operation_cost": "pumped_hydro_operation_cost",
-      "ext": "get_component_ext"
+      "ext": "pumped_hydro_ext"
     },
     "filter": {
       "casefold": true,

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -295,6 +295,7 @@
       "category": "pumped-hydro",
       "active_power": 0.0,
       "reactive_power": 0.0,
+      "time_at_status": 0.0,
       "reactive_power_limits": null,
       "outflow_limits": null,
       "powerhouse_elevation": 0.0,

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -324,7 +324,7 @@
       "bus": "get_bus_for_region",
       "services": "get_gen_services",
       "rating": "storage_rating",
-      "base_power": "storage_rating",
+      "base_power": "storage_base_power",
       "active_power_limits": "storage_power_limits",
       "active_power_limits_pump": "storage_power_limits",
       "efficiency": "pumped_hydro_efficiency",

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getter_utils.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getter_utils.py
@@ -6,6 +6,9 @@ import logging
 from numbers import Real
 from typing import Any, cast
 
+import numpy as np
+from infrasys import SingleTimeSeries
+
 from r2x_core import PluginContext, replace_single_time_series
 
 logger = logging.getLogger(__name__)
@@ -95,6 +98,76 @@ def normalize_max_active_power_time_series(context: PluginContext) -> None:
         )
 
     logger.info("Normalized %s max_active_power time series for Sienna", normalized)
+
+
+def attach_pumped_hydro_inflow_time_series(context: PluginContext) -> None:
+    """Attach zero inflow profiles to translated pumped-hydro reservoirs."""
+    from r2x_reeds.models import ReEDSDemand
+    from r2x_sienna.models import HydroPumpTurbine, HydroReservoir
+
+    if context.source_system is None or context.target_system is None:
+        return
+
+    source_sys = cast(Any, context.source_system)
+    target_sys = cast(Any, context.target_system)
+    reservoirs = [
+        reservoir
+        for reservoir in target_sys.get_components(HydroReservoir)
+        if any(
+            isinstance(turbine, HydroPumpTurbine)
+            for turbine in (*reservoir.upstream_turbines, *reservoir.downstream_turbines)
+        )
+    ]
+    if not reservoirs:
+        return
+
+    timelines: dict[tuple[tuple[str, str], ...], tuple[SingleTimeSeries, dict[str, Any]]] = {}
+    for demand in source_sys.get_components(ReEDSDemand):
+        for metadata in source_sys.time_series.list_time_series_metadata(
+            demand,
+            name="max_active_power",
+        ):
+            features = dict(metadata.features)
+            key = tuple(sorted((str(name), repr(value)) for name, value in features.items()))
+            if key in timelines:
+                continue
+            time_series = source_sys.list_time_series(
+                demand,
+                name=metadata.name,
+                time_series_type=SingleTimeSeries,
+                **features,
+            )
+            if time_series:
+                timelines[key] = (time_series[0], features)
+
+    if not timelines:
+        logger.warning("No demand time series available for pumped-hydro reservoir inflow profiles.")
+        return
+
+    attached = 0
+    for reference, features in timelines.values():
+        owners = [
+            reservoir
+            for reservoir in reservoirs
+            if not target_sys.has_time_series(
+                reservoir,
+                name="inflow",
+                time_series_type=SingleTimeSeries,
+                **features,
+            )
+        ]
+        if not owners:
+            continue
+        inflow = SingleTimeSeries.from_array(
+            data=np.zeros(len(reference.data), dtype=float),
+            name="inflow",
+            initial_timestamp=reference.initial_timestamp,
+            resolution=reference.resolution,
+        )
+        target_sys.add_time_series(inflow, *owners, **features)
+        attached += len(owners)
+
+    logger.info("Attached zero inflow time series to %s pumped-hydro reservoirs.", attached)
 
 
 def add_generator_emissions(context: PluginContext) -> None:

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getter_utils.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getter_utils.py
@@ -37,7 +37,6 @@ def _get_source_max_active_power(component: Any) -> float | None:
 
 def normalize_max_active_power_time_series(context: PluginContext) -> None:
     """Normalize ReEDS MW profiles for PowerSystems scaling during serialization."""
-    from infrasys import SingleTimeSeries
     from infrasys.normalization import NormalizationByValue
     from r2x_sienna.exporter import set_time_series_scaling_factor_multiplier
 

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -1001,7 +1001,7 @@ def storage_base_power(component: ReEDSStorage, context: PluginContext) -> Resul
 
 
 def _storage_capacity_mwh(component: ReEDSStorage) -> float:
-    """Return storage energy capacity in MWh."""
+    """Energy capacity from explicit value or duration * power."""
     energy = getattr(component, "energy_capacity", None)
     if energy is not None:
         return float(energy)

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -113,17 +113,13 @@ def _lookup_area(context: PluginContext, name: str | None) -> Area | None:
     return None
 
 
-@getter
-def get_component_ext(component: object, context: PluginContext) -> Result[dict, ValueError]:
-    """
-    Get the component's ext dict, storing the technology name under the 'technology' key
-    and the ReEDS line type under the 'reeds_line_type' key.
-    """
+def _component_ext(component: object) -> dict:
+    """Copy component metadata and include its technology name and ReEDS line type."""
     ext = getattr(component, "ext", None)
     if ext is None:
         ext = {}
     elif not isinstance(ext, dict):
-        return Err(ValueError("Component ext attribute is not a dict"))
+        raise ValueError("Component ext attribute is not a dict")
 
     ext = dict(ext)
     technology = getattr(component, "technology", None)
@@ -134,7 +130,19 @@ def get_component_ext(component: object, context: PluginContext) -> Result[dict,
     if line_type is not None:
         ext["reeds_line_type"] = line_type
 
-    return Ok(ext)
+    return ext
+
+
+@getter
+def get_component_ext(component: object, context: PluginContext) -> Result[dict, ValueError]:
+    """
+    Get the component's ext dict, storing the technology name under the 'technology' key
+    and the ReEDS line type under the 'reeds_line_type' key.
+    """
+    try:
+        return Ok(_component_ext(component))
+    except ValueError as e:
+        return Err(e)
 
 
 @getter
@@ -963,16 +971,17 @@ def hydro_time_limits(component: ReEDSHydroGenerator, context: PluginContext) ->
 def hydro_operation_cost(
     component: ReEDSHydroGenerator, context: PluginContext
 ) -> Result[HydroGenerationCost, ValueError]:
-    """Return zeroed hydro cost."""
+    """Map ReEDS variable O&M to a hydro generation cost."""
     from r2x_sienna.models.costs import HydroGenerationCost
 
+    vom_cost = float(getattr(component, "vom_cost", 0.0) or 0.0)
     return Ok(
         HydroGenerationCost(
             fixed=0.0,
             variable=CostCurve(
-                value_curve=LinearCurve(10),
+                value_curve=LinearCurve(0.0),
                 power_units=InfraUnitSystem.NATURAL_UNITS,
-                vom_cost=LinearCurve(5.0),
+                vom_cost=LinearCurve(vom_cost),
             ),
         )
     )
@@ -1100,18 +1109,32 @@ def pumped_hydro_efficiency(
 def pumped_hydro_operation_cost(
     component: ReEDSStorage, context: PluginContext
 ) -> Result[HydroGenerationCost, ValueError]:
-    """Map ReEDS variable O&M to a pumped-hydro generation cost."""
-    vom_cost = float(getattr(component, "vom_cost", 0.0) or 0.0)
+    """Return a zero operating cost for pumped hydro."""
+    # ReEDS applies pumped-hydro VOM only to generation, while HydroPowerSimulations applies
+    # this shared cost to both generation and pumping. We set it to zero to avoid
+    # charging the generation-only ReEDS VOM during pumping. The original value
+    # is preserved in the component metadata by pumped_hydro_ext.
     return Ok(
         HydroGenerationCost(
             fixed=0.0,
             variable=CostCurve(
                 value_curve=LinearCurve(0.0),
                 power_units=InfraUnitSystem.NATURAL_UNITS,
-                vom_cost=LinearCurve(vom_cost),
+                vom_cost=LinearCurve(0.0),
             ),
         )
     )
+
+
+@getter
+def pumped_hydro_ext(component: ReEDSStorage, context: PluginContext) -> Result[dict, ValueError]:
+    """Preserve the generation-only ReEDS VOM in pumped-hydro metadata."""
+    try:
+        ext = _component_ext(component)
+    except ValueError as e:
+        return Err(e)
+    ext["reeds_vom_cost"] = float(getattr(component, "vom_cost", 0.0) or 0.0)
+    return Ok(ext)
 
 
 @getter

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -991,6 +991,16 @@ def storage_base_power(component: ReEDSStorage, context: PluginContext) -> Resul
     return _ok_num(float(getattr(component, "capacity", 0.0) or 0.0))
 
 
+def _storage_capacity_mwh(component: ReEDSStorage) -> float:
+    """Return storage energy capacity in MWh."""
+    energy = getattr(component, "energy_capacity", None)
+    if energy is not None:
+        return float(energy)
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+    duration = float(getattr(component, "storage_duration", 0.0) or 0.0)
+    return capacity * duration
+
+
 @getter
 def storage_capacity_device_base(
     component: ReEDSStorage, context: PluginContext
@@ -1074,7 +1084,7 @@ def pumped_hydro_storage_level_limits(
     component: ReEDSStorage, context: PluginContext
 ) -> Result[MinMax, ValueError]:
     """Return pumped-hydro reservoir limits in MWh."""
-    return storage_capacity_mwh(component, context).map(lambda capacity: MinMax(min=0.0, max=float(capacity)))
+    return Ok(MinMax(min=0.0, max=_storage_capacity_mwh(component)))
 
 
 @getter
@@ -1090,8 +1100,18 @@ def pumped_hydro_efficiency(
 def pumped_hydro_operation_cost(
     component: ReEDSStorage, context: PluginContext
 ) -> Result[HydroGenerationCost, ValueError]:
-    """Return a neutral operating cost for a pumped-hydro turbine."""
-    return Ok(HydroGenerationCost())
+    """Map ReEDS variable O&M to a pumped-hydro generation cost."""
+    vom_cost = float(getattr(component, "vom_cost", 0.0) or 0.0)
+    return Ok(
+        HydroGenerationCost(
+            fixed=0.0,
+            variable=CostCurve(
+                value_curve=LinearCurve(0.0),
+                power_units=InfraUnitSystem.NATURAL_UNITS,
+                vom_cost=LinearCurve(vom_cost),
+            ),
+        )
+    )
 
 
 @getter

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -10,9 +10,14 @@ from typing import TYPE_CHECKING, Any, cast
 from infrasys.cost_curves import CostCurve, FuelCurve, LinearCurve
 from infrasys.cost_curves import UnitSystem as InfraUnitSystem
 from r2x_sienna.models import ACBus, Arc
-from r2x_sienna.models.costs import HydroGenerationCost, RenewableGenerationCost, ThermalGenerationCost
+from r2x_sienna.models.costs import (
+    HydroGenerationCost,
+    HydroReservoirCost,
+    RenewableGenerationCost,
+    ThermalGenerationCost,
+)
 from r2x_sienna.models.enums import ACBusTypes, PrimeMoversType, StorageTechs, ThermalFuels
-from r2x_sienna.models.named_tuples import FromTo_ToFrom, InputOutput, MinMax, UpDown
+from r2x_sienna.models.named_tuples import FromTo_ToFrom, InputOutput, MinMax, TurbinePump, UpDown
 from r2x_sienna.units import ureg
 
 from r2x_core import Err, Ok, Result
@@ -1050,6 +1055,69 @@ def storage_conversion_factor(
 ) -> Result[float | int, ValueError]:
     """Default conversion factor."""
     return _ok_num(1.0)
+
+
+@getter
+def pumped_hydro_head_name(component: ReEDSStorage, context: PluginContext) -> Result[str, ValueError]:
+    """Append the head-reservoir suffix to a pumped-hydro component name."""
+    return Ok(f"{component.name}_head")
+
+
+@getter
+def pumped_hydro_tail_name(component: ReEDSStorage, context: PluginContext) -> Result[str, ValueError]:
+    """Append the tail-reservoir suffix to a pumped-hydro component name."""
+    return Ok(f"{component.name}_tail")
+
+
+@getter
+def pumped_hydro_storage_level_limits(
+    component: ReEDSStorage, context: PluginContext
+) -> Result[MinMax, ValueError]:
+    """Return pumped-hydro reservoir limits in MWh."""
+    return storage_capacity_mwh(component, context).map(lambda capacity: MinMax(min=0.0, max=float(capacity)))
+
+
+@getter
+def pumped_hydro_efficiency(
+    component: ReEDSStorage, context: PluginContext
+) -> Result[TurbinePump, ValueError]:
+    """Apply the ReEDS storage efficiency to pumping only."""
+    efficiency = float(getattr(component, "round_trip_efficiency", 1.0) or 1.0)
+    return Ok(TurbinePump(turbine=1.0, pump=efficiency))
+
+
+@getter
+def pumped_hydro_operation_cost(
+    component: ReEDSStorage, context: PluginContext
+) -> Result[HydroGenerationCost, ValueError]:
+    """Return a neutral operating cost for a pumped-hydro turbine."""
+    return Ok(HydroGenerationCost())
+
+
+@getter
+def hydro_reservoir_operation_cost(
+    component: ReEDSStorage, context: PluginContext
+) -> Result[HydroReservoirCost, ValueError]:
+    """Return a zeroed operating cost for a pumped-hydro reservoir."""
+    return Ok(HydroReservoirCost())
+
+
+@getter
+def get_pumped_hydro_turbine(component: ReEDSStorage, context: PluginContext) -> Result[list, ValueError]:
+    """Return the translated pumped-hydro turbine for reservoir linkage."""
+    from r2x_sienna.models import HydroPumpTurbine
+
+    turbine = next(
+        (
+            candidate
+            for candidate in _target_system(context).get_components(HydroPumpTurbine)
+            if candidate.name == component.name
+        ),
+        None,
+    )
+    if turbine is None:
+        return Err(ValueError(f"Could not find HydroPumpTurbine for {component.name}"))
+    return Ok([turbine])
 
 
 @getter

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/translation.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/translation.py
@@ -12,6 +12,7 @@ from infrasys.utils.sqlite import create_in_memory_db
 from r2x_core import PluginContext, Rule, System, apply_rules_to_context, expose_plugin
 from r2x_reeds_to_sienna.getter_utils import (
     add_generator_emissions,
+    attach_pumped_hydro_inflow_time_series,
     normalize_max_active_power_time_series,
 )
 from r2x_reeds_to_sienna.plugin_config import ReEDSToSiennaConfig
@@ -56,6 +57,7 @@ def reeds_to_sienna(system: System, config: ReEDSToSiennaConfig) -> System:
     apply_rules_to_context(context)
 
     normalize_max_active_power_time_series(context)
+    attach_pumped_hydro_inflow_time_series(context)
     add_generator_emissions(context)
 
     return context.target_system

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -336,6 +336,23 @@ def test_bus_number_with_z_prefix(tmp_path) -> None:
     assert result == 122
 
 
+def test_get_pumped_hydro_turbine_returns_error_when_missing(tmp_path) -> None:
+    """The pumped-hydro linkage getter reports a missing turbine."""
+    context = make_context(tmp_path)
+    context.target_system = System(name="target")
+    region = ReEDSRegion(name="p1")
+    storage = ReEDSStorage(
+        name="p1_PSH",
+        region=region,
+        technology="pumped-hydro",
+        capacity=4.0,
+        storage_duration=2.0,
+        round_trip_efficiency=0.8,
+    )
+
+    assert getters.get_pumped_hydro_turbine(storage, context).is_err()
+
+
 def test_get_gen_services_all_generator_types(tmp_path) -> None:
     """get_gen_services must work for all generator types, not just thermal.
 

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -81,15 +81,42 @@ def test_has_generator_rules() -> None:
     ), "Missing ReEDSHydroGenerator -> HydroDispatch rule"
 
 
-def test_has_storage_rule() -> None:
-    """Verify ReEDSStorage maps to EnergyReservoirStorage."""
+def test_has_storage_rules() -> None:
+    """Verify battery and pumped-hydro storage rules."""
     rules_path = files("r2x_reeds_to_sienna.config") / "rules.json"
     rules_data = json.loads(rules_path.read_text())
 
     assert any(
-        rule.get("source_type") == "ReEDSStorage" and rule.get("target_type") == "EnergyReservoirStorage"
+        rule.get("source_type") == "ReEDSStorage"
+        and rule.get("target_type") == "EnergyReservoirStorage"
+        and rule.get("filter", {}).get("op") == "not_in"
+        and "pumped-hydro" in rule.get("filter", {}).get("values", [])
         for rule in rules_data
     ), "Missing ReEDSStorage -> EnergyReservoirStorage rule"
+
+    assert any(
+        rule.get("name") == "pumped_hydro_turbine"
+        and rule.get("source_type") == "ReEDSStorage"
+        and rule.get("target_type") == "HydroPumpTurbine"
+        and "pumped-hydro" in rule.get("filter", {}).get("values", [])
+        for rule in rules_data
+    ), "Missing pumped-hydro ReEDSStorage -> HydroPumpTurbine rule"
+
+    assert any(
+        rule.get("name") == "pumped_hydro_head_reservoir"
+        and rule.get("source_type") == "ReEDSStorage"
+        and rule.get("target_type") == "HydroReservoir"
+        and "pumped-hydro" in rule.get("filter", {}).get("values", [])
+        for rule in rules_data
+    ), "Missing pumped-hydro head HydroReservoir rule"
+
+    assert any(
+        rule.get("name") == "pumped_hydro_tail_reservoir"
+        and rule.get("source_type") == "ReEDSStorage"
+        and rule.get("target_type") == "HydroReservoir"
+        and "pumped-hydro" in rule.get("filter", {}).get("values", [])
+        for rule in rules_data
+    ), "Missing pumped-hydro tail HydroReservoir rule"
 
 
 def test_has_interface_rule() -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -82,7 +82,7 @@ def test_has_generator_rules() -> None:
 
 
 def test_has_storage_rules() -> None:
-    """Verify battery and pumped-hydro storage rules."""
+    """Verify ReEDSStorage maps to EnergyReservoirStorage and pumped-hydro types."""
     rules_path = files("r2x_reeds_to_sienna.config") / "rules.json"
     rules_data = json.loads(rules_path.read_text())
 

--- a/packages/r2x-reeds-to-sienna/tests/test_translation.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import numpy as np
 import pytest
 from infrasys import SingleTimeSeries
 from infrasys.normalization import NormalizationByValue
@@ -30,6 +31,8 @@ from r2x_sienna.models import (
     AreaInterchange,
     EnergyReservoirStorage,
     HydroDispatch,
+    HydroPumpTurbine,
+    HydroReservoir,
     Line,
     PowerLoad,
     RenewableDispatch,
@@ -206,6 +209,49 @@ def test_reeds_to_sienna_translates_storage():
 
     storages = list(result.get_components(EnergyReservoirStorage))
     assert any(s.name == "battery_p1" for s in storages)
+
+
+def test_reeds_to_sienna_attaches_pumped_hydro_inflow_time_series():
+    source = _build_source_system()
+    region = source.get_component(ReEDSRegion, name="p1")
+    demand = source.get_component(ReEDSDemand, name="load_p1")
+    source.add_component(
+        ReEDSStorage(
+            name="pumped-hydro_p1",
+            category="pumped-hydro",
+            region=region,
+            technology="pumped-hydro",
+            capacity=50.0,
+            storage_duration=4.0,
+            round_trip_efficiency=0.8,
+        )
+    )
+    reference = SingleTimeSeries.from_array(
+        data=np.arange(24, dtype=float),
+        name="max_active_power",
+        initial_timestamp=datetime(2012, 1, 1),
+        resolution=timedelta(hours=1),
+    )
+    source.add_time_series(reference, demand, solve_year=2050, weather_year=2012)
+
+    result = reeds_to_sienna(source, config=ReEDSToSiennaConfig())
+
+    turbine = result.get_component(HydroPumpTurbine, name="pumped-hydro_p1")
+    reservoirs = list(result.get_components(HydroReservoir))
+    assert len(reservoirs) == 2
+    for reservoir in reservoirs:
+        inflow = result.list_time_series(
+            reservoir,
+            name="inflow",
+            solve_year=2050,
+            weather_year=2012,
+        )
+        assert len(inflow) == 1
+        assert np.array_equal(inflow[0].data, np.zeros(24))
+        assert inflow[0].initial_timestamp == reference.initial_timestamp
+        assert inflow[0].resolution == reference.resolution
+
+    assert not result.has_time_series(turbine, name="inflow")
 
 
 def test_reeds_to_sienna_translates_demand_to_load():

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -280,7 +280,7 @@ def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> No
             vom_cost=0.38,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -300,10 +300,10 @@ def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> No
     tail = reservoirs_by_name["PSH1_tail"]
 
     assert turbine.name == "PSH1"
-    assert turbine.rating == 50.0
+    assert turbine.rating == 1.0
     assert turbine.base_power == 50.0
-    assert turbine.active_power_limits.max == 50.0
-    assert turbine.active_power_limits_pump.max == 50.0
+    assert turbine.active_power_limits.max == 1.0
+    assert turbine.active_power_limits_pump.max == 1.0
     assert turbine.time_at_status == 0.0
     assert turbine.efficiency.turbine == 1.0
     assert turbine.efficiency.pump == 0.8

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -190,6 +190,7 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
             capacity=100.0,
             is_dispatchable=True,
             ramp_rate=10.0,
+            vom_cost=1.02,
         )
     )
     context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
@@ -210,6 +211,10 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
     assert hydro.ramp_limits.up == pytest.approx(10.0 / 60.0)
     assert hydro.time_limits.up == 0.0
     assert hydro.time_limits.down == 0.0
+    assert hydro.operation_cost.fixed == 0.0
+    assert hydro.operation_cost.variable is not None
+    assert hydro.operation_cost.variable.value_curve.function_data.proportional_term == 0.0
+    assert hydro.operation_cost.variable.vom_cost.function_data.proportional_term == pytest.approx(1.02)
 
 
 def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:
@@ -304,7 +309,8 @@ def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> No
     assert turbine.efficiency.pump == 0.8
     assert turbine.operation_cost.fixed == 0.0
     assert turbine.operation_cost.variable is not None
-    assert turbine.operation_cost.variable.vom_cost.function_data.proportional_term == pytest.approx(0.38)
+    assert turbine.operation_cost.variable.vom_cost.function_data.proportional_term == 0.0
+    assert turbine.ext["reeds_vom_cost"] == pytest.approx(0.38)
 
     assert head.storage_level_limits.max == 200.0
     assert tail.storage_level_limits.max == 200.0

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -213,7 +213,6 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
     assert hydro.time_limits.down == 0.0
     assert hydro.operation_cost.fixed == 0.0
     assert hydro.operation_cost.variable is not None
-    assert hydro.operation_cost.variable.value_curve.function_data.proportional_term == 0.0
     assert hydro.operation_cost.variable.vom_cost.function_data.proportional_term == pytest.approx(1.02)
 
 
@@ -305,6 +304,7 @@ def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> No
     assert turbine.base_power == 50.0
     assert turbine.active_power_limits.max == 50.0
     assert turbine.active_power_limits_pump.max == 50.0
+    assert turbine.time_at_status == 0.0
     assert turbine.efficiency.turbine == 1.0
     assert turbine.efficiency.pump == 0.8
     assert turbine.operation_cost.fixed == 0.0

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -273,6 +273,7 @@ def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> No
             capacity=50.0,
             storage_duration=4.0,
             round_trip_efficiency=0.8,
+            vom_cost=0.38,
         )
     )
     context.target_system = System(name="target", auto_add_composed_components=True)
@@ -302,7 +303,8 @@ def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> No
     assert turbine.efficiency.turbine == 1.0
     assert turbine.efficiency.pump == 0.8
     assert turbine.operation_cost.fixed == 0.0
-    assert turbine.operation_cost.variable is None
+    assert turbine.operation_cost.variable is not None
+    assert turbine.operation_cost.variable.vom_cost.function_data.proportional_term == pytest.approx(0.38)
 
     assert head.storage_level_limits.max == 200.0
     assert tail.storage_level_limits.max == 200.0
@@ -637,7 +639,12 @@ def test_gen_services_attaches_non_spinning_reserve_to_generator(tmp_path) -> No
     an empty services list even after the reserve was translated.
     """
     from r2x_reeds.models import ReEDSRegion, ReEDSReserve, ReEDSStorage, ReEDSThermalGenerator
-    from r2x_sienna.models import EnergyReservoirStorage, ThermalStandard, VariableReserveNonSpinning
+    from r2x_sienna.models import (
+        EnergyReservoirStorage,
+        HydroPumpTurbine,
+        ThermalStandard,
+        VariableReserveNonSpinning,
+    )
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -676,6 +683,17 @@ def test_gen_services_attaches_non_spinning_reserve_to_generator(tmp_path) -> No
             ext={"reserves": ["NON_SPIN_UP"]},
         )
     )
+    context.source_system.add_component(
+        ReEDSStorage(
+            name="PSH1",
+            region=region,
+            technology="pumped-hydro",
+            capacity=50.0,
+            storage_duration=12.0,
+            round_trip_efficiency=0.8,
+            ext={"reserves": ["NON_SPIN_UP"]},
+        )
+    )
 
     context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
@@ -697,6 +715,12 @@ def test_gen_services_attaches_non_spinning_reserve_to_generator(tmp_path) -> No
     assert (
         non_spin in storages[0].services
     ), "EnergyReservoirStorage must have the VariableReserveNonSpinning in its services"
+
+    pumped_hydro = list(context.target_system.get_components(HydroPumpTurbine))
+    assert len(pumped_hydro) == 1
+    assert (
+        non_spin in pumped_hydro[0].services
+    ), "HydroPumpTurbine must have the VariableReserveNonSpinning in its services"
 
 
 def test_reeds_spinning_reserve_does_not_produce_non_spinning(tmp_path) -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -251,6 +251,71 @@ def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:
     assert storage.efficiency.output == pytest.approx(1.0)
 
 
+def test_reeds_pumped_hydro_translates_to_turbine_and_reservoirs(tmp_path) -> None:
+    from r2x_reeds.models import ReEDSRegion, ReEDSStorage
+    from r2x_sienna.models import (
+        EnergyReservoirStorage,
+        HydroPumpTurbine,
+        HydroReservoir,
+        ReservoirDataType,
+        ReservoirLocation,
+    )
+
+    context, rules = make_context_and_rules(tmp_path)
+    context.source_system = System(name="source", auto_add_composed_components=True)
+    region = ReEDSRegion(name="p1", category="region")
+    context.source_system.add_component(region)
+    context.source_system.add_component(
+        ReEDSStorage(
+            name="PSH1",
+            region=region,
+            technology="pumped-hydro",
+            capacity=50.0,
+            storage_duration=4.0,
+            round_trip_efficiency=0.8,
+        )
+    )
+    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.rules = rules
+
+    result = apply_rules_to_context(context)
+    assert result.total_rules > 0
+
+    assert list(context.target_system.get_components(EnergyReservoirStorage)) == []
+
+    turbines = list(context.target_system.get_components(HydroPumpTurbine))
+    reservoirs = list(context.target_system.get_components(HydroReservoir))
+
+    assert len(turbines) == 1
+    assert len(reservoirs) == 2
+
+    turbine = turbines[0]
+    reservoirs_by_name = {reservoir.name: reservoir for reservoir in reservoirs}
+    head = reservoirs_by_name["PSH1_head"]
+    tail = reservoirs_by_name["PSH1_tail"]
+
+    assert turbine.name == "PSH1"
+    assert turbine.rating == 50.0
+    assert turbine.base_power == 50.0
+    assert turbine.active_power_limits.max == 50.0
+    assert turbine.active_power_limits_pump.max == 50.0
+    assert turbine.efficiency.turbine == 1.0
+    assert turbine.efficiency.pump == 0.8
+    assert turbine.operation_cost.fixed == 0.0
+    assert turbine.operation_cost.variable is None
+
+    assert head.storage_level_limits.max == 200.0
+    assert tail.storage_level_limits.max == 200.0
+    assert head.initial_level == 0.5
+    assert tail.initial_level == 0.5
+    assert head.level_data_type == ReservoirDataType.ENERGY
+    assert tail.level_data_type == ReservoirDataType.ENERGY
+    assert head.reservoir_location == ReservoirLocation.HEAD
+    assert tail.reservoir_location == ReservoirLocation.TAIL
+    assert head.downstream_turbines == [turbine]
+    assert tail.upstream_turbines == [turbine]
+
+
 def test_reeds_demand_translates_to_power_load(tmp_path) -> None:
     from r2x_reeds.models import ReEDSDemand, ReEDSRegion
     from r2x_sienna.models import PowerLoad


### PR DESCRIPTION
## Sienna
Pumped hydro was previously translated as `EnergyReservoirStorage`, which did not preserve the physical relationship between pumping, generation and the head and tail reservoirs. 

This PR maps ReEDS pumped hydro to `HydroPumpTurbine` with linked head and tail `HydroReservoir` components. It preserves the ReEDS power and energy capacities, applies the ReEDS storage efficiency during pumping and retains reserve memberships. Because the ReEDS pumped hydro representation does not provide external water inflow, the translator also attaches explicit zero inflow profiles to both reservoirs, which provides the inflow input expected by the HydroPowerSimulations reservoir formulation. The PR also maps ReEDS variable operating costs for conventional hydro to `HydroDispatch`. 

## PLEXOS
PLEXOS pumped hydro generators previously received a zero `VO&M Charge` even when ReEDS provided a nonzero generation VO&M.

This PR correctly maps the ReEDS pumped hydro VO&M to the PLEXOS generator property. 

