### PR TITLE
fix: Map ReEDS hydro by operating mode in Sienna

### DIFF
--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -224,6 +224,11 @@
       "uuid": "uuid",
       "category": "technology"
     },
+    "filter": {
+      "field": "is_dispatchable",
+      "op": "eq",
+      "values": [true]
+    },
     "getters": {
       "bus": "get_bus_for_region",
       "active_power": "get_zero_active_power",
@@ -243,6 +248,38 @@
     "depends_on": ["region_bus", "variable_reserve"],
     "source_type": "ReEDSHydroGenerator",
     "target_type": "HydroDispatch",
+    "version": 1
+  },
+  {
+    "name": "hydro_gen_nondispatch",
+    "defaults": {
+      "category": "hydro",
+      "active_power": 0.0,
+      "reactive_power": 0.0
+    },
+    "field_map": {
+      "name": "name",
+      "uuid": "uuid",
+      "category": "technology"
+    },
+    "filter": {
+      "field": "is_dispatchable",
+      "op": "eq",
+      "values": [false]
+    },
+    "getters": {
+      "bus": "get_bus_for_region",
+      "active_power": "get_zero_active_power",
+      "services": "get_gen_services",
+      "reactive_power": "get_zero_reactive_power",
+      "rating": "hydro_rating",
+      "base_power": "hydro_base_power",
+      "prime_mover_type": "get_hydro_prime_mover",
+      "ext": "get_component_ext"
+    },
+    "depends_on": ["region_bus", "variable_reserve"],
+    "source_type": "ReEDSHydroGenerator",
+    "target_type": "RenewableNonDispatch",
     "version": 1
   },
   {

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -275,7 +275,7 @@
       "rating": "hydro_rating",
       "base_power": "hydro_base_power",
       "prime_mover_type": "get_hydro_prime_mover",
-      "ext": "get_component_ext"
+      "ext": "nondispatchable_hydro_ext"
     },
     "depends_on": ["region_bus", "variable_reserve"],
     "source_type": "ReEDSHydroGenerator",

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -968,6 +968,19 @@ def hydro_time_limits(component: ReEDSHydroGenerator, context: PluginContext) ->
 
 
 @getter
+def nondispatchable_hydro_ext(
+    component: ReEDSHydroGenerator, context: PluginContext
+) -> Result[dict, ValueError]:
+    """Preserve ReEDS VOM that RenewableNonDispatch cannot represent."""
+    try:
+        ext = _component_ext(component)
+    except ValueError as e:
+        return Err(e)
+    ext["reeds_vom_cost"] = float(getattr(component, "vom_cost", 0.0) or 0.0)
+    return Ok(ext)
+
+
+@getter
 def hydro_operation_cost(
     component: ReEDSHydroGenerator, context: PluginContext
 ) -> Result[HydroGenerationCost, ValueError]:

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -74,11 +74,20 @@ def test_has_generator_rules() -> None:
         for rule in rules_data
     ), "Missing ReEDSVariableGenerator -> RenewableNonDispatch (distpv) rule"
 
-    # Hydro generator
+    # Hydro generators
     assert any(
-        rule.get("source_type") == "ReEDSHydroGenerator" and rule.get("target_type") == "HydroDispatch"
+        rule.get("source_type") == "ReEDSHydroGenerator"
+        and rule.get("target_type") == "HydroDispatch"
+        and rule.get("filter", {}).get("values") == [True]
         for rule in rules_data
-    ), "Missing ReEDSHydroGenerator -> HydroDispatch rule"
+    ), "Missing dispatchable ReEDSHydroGenerator -> HydroDispatch rule"
+
+    assert any(
+        rule.get("source_type") == "ReEDSHydroGenerator"
+        and rule.get("target_type") == "RenewableNonDispatch"
+        and rule.get("filter", {}).get("values") == [False]
+        for rule in rules_data
+    ), "Missing nondispatchable ReEDSHydroGenerator -> RenewableNonDispatch rule"
 
 
 def test_has_storage_rules() -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -174,9 +174,9 @@ def test_reeds_generators_translate_to_sienna_types(tmp_path) -> None:
     assert pv.bus == buses[0]
 
 
-def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
+def test_reeds_hydro_translates_by_operating_mode(tmp_path) -> None:
     from r2x_reeds.models import ReEDSHydroGenerator, ReEDSRegion
-    from r2x_sienna.models import HydroDispatch
+    from r2x_sienna.models import HydroDispatch, PrimeMoversType, RenewableNonDispatch
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -184,13 +184,22 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
     context.source_system.add_component(region)
     context.source_system.add_component(
         ReEDSHydroGenerator(
-            name="HYDRO1",
+            name="HYDRO_DISPATCH",
             region=region,
             technology="hydro",
             capacity=100.0,
             is_dispatchable=True,
             ramp_rate=10.0,
             vom_cost=1.02,
+        )
+    )
+    context.source_system.add_component(
+        ReEDSHydroGenerator(
+            name="HYDRO_NONDISPATCH",
+            region=region,
+            technology="hydro",
+            capacity=50.0,
+            is_dispatchable=False,
         )
     )
     context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
@@ -203,7 +212,7 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
     assert len(hydros) == 1
 
     hydro = hydros[0]
-    assert hydro.name == "HYDRO1"
+    assert hydro.name == "HYDRO_DISPATCH"
     assert hydro.category == "hydro"
     assert hydro.rating == 1.0
     assert hydro.base_power == 100.0
@@ -214,6 +223,16 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
     assert hydro.operation_cost.fixed == 0.0
     assert hydro.operation_cost.variable is not None
     assert hydro.operation_cost.variable.vom_cost.function_data.proportional_term == pytest.approx(1.02)
+
+    nondispatchable_hydros = list(context.target_system.get_components(RenewableNonDispatch))
+    assert len(nondispatchable_hydros) == 1
+
+    nondispatchable_hydro = nondispatchable_hydros[0]
+    assert nondispatchable_hydro.name == "HYDRO_NONDISPATCH"
+    assert nondispatchable_hydro.category == "hydro"
+    assert nondispatchable_hydro.rating == 1.0
+    assert nondispatchable_hydro.base_power == 50.0
+    assert nondispatchable_hydro.prime_mover_type == PrimeMoversType.HY
 
 
 def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -200,6 +200,7 @@ def test_reeds_hydro_translates_by_operating_mode(tmp_path) -> None:
             technology="hydro",
             capacity=50.0,
             is_dispatchable=False,
+            vom_cost=1.02,
         )
     )
     context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
@@ -233,6 +234,7 @@ def test_reeds_hydro_translates_by_operating_mode(tmp_path) -> None:
     assert nondispatchable_hydro.rating == 1.0
     assert nondispatchable_hydro.base_power == 50.0
     assert nondispatchable_hydro.prime_mover_type == PrimeMoversType.HY
+    assert nondispatchable_hydro.ext["reeds_vom_cost"] == pytest.approx(1.02)
 
 
 def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:


### PR DESCRIPTION
ReEDS distinguishes between dispatchable and nondispatchable conventional hydro. Previously both operating modes were translated to `HydroDispatch`, which allowed nondispatchable hydro to be dispatched by the Sienna optimization.

This PR maps dispatchable ReEDS hydro to `HydroDispatch` and nondispatchable ReEDS hydro to `RenewableNonDispatch`. 