### PR TITLE
fix: ReEDS hydro operating mode translation to PLEXOS

### DIFF
--- a/packages/r2x-reeds-to-plexos/README.md
+++ b/packages/r2x-reeds-to-plexos/README.md
@@ -50,7 +50,7 @@ Translation rules are defined in `config/rules.json`. These rules specify how Re
 
 Set `hydro_budget_ts` on the translation plugin to control the PLEXOS hydro
 energy constraint resolution. Supported values are `hourly`, `daily`, `weekly`,
-and `monthly`; the default is `hourly`, which preserves the ReEDS series.
+and `monthly`; the default is `daily`, which preserves ReEDS daily hydro flexibility.
 
 ```yaml
 config:
@@ -59,6 +59,5 @@ config:
         hydro_budget_ts: monthly
 ```
 
-The `daily`, `weekly`, and `monthly` modes convert the ReEDS hourly series of
-repeated daily-energy budgets into energy totals for the selected PLEXOS
-constraint period.
+The ReEDS capacity-factor series is combined with generator capacity to create
+energy totals for the selected PLEXOS constraint period.

--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters.py
@@ -166,8 +166,11 @@ def region_ext(component: ReEDSRegion, context: PluginContext) -> Result[dict, V
 def hydro_max_energy_per_day(
     component: ReEDSHydroGenerator, context: PluginContext
 ) -> Result[float | int, ValueError]:
-    """Return the maximum energy per day for a hydro generator as a PLEXOSPropertyValue with units MW."""
-    value = _float_or_zero(getattr(component, "max_energy_per_day", 0.0))
+    """Return the maximum daily hydro energy or the PLEXOS default."""
+    value = getattr(component, "max_energy_per_day", None)
+    if value is None:
+        return Ok(1e30)
+    value = _float_or_zero(value)
     return Ok(value)
 
 

--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters_utils.py
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/getters_utils.py
@@ -109,52 +109,52 @@ def attach_reserve_time_series(context: PluginContext) -> None:
                 context.target_system.add_time_series(deepcopy(ts), reserve)
 
 
-def _convert_hydro_budget_time_series(ts: Any, cadence: str, *, budget_year: int | None = None) -> Any:
-    """Convert ReEDS hourly MWh budgets to a PLEXOS resolution in GWh."""
-    if cadence == "hourly":
-        return deepcopy(ts)
-
+def _convert_hydro_budget_time_series(ts: Any, cadence: str, capacity: float) -> Any:
+    """Convert ReEDS hourly capacity factors to PLEXOS hydro energy limits."""
     from infrasys import SingleTimeSeries
 
     if not isinstance(ts, SingleTimeSeries) or ts.resolution != timedelta(hours=1):
-        logger.warning(
-            "Cannot convert hydro_budget with type {} and resolution {}; leaving it unchanged.",
-            type(ts).__name__,
-            getattr(ts, "resolution", None),
+        raise ValueError(
+            "hydro_budget must be an hourly SingleTimeSeries; "
+            f"got {type(ts).__name__} with resolution {getattr(ts, 'resolution', None)}"
         )
-        return deepcopy(ts)
 
-    hourly_values = list(ts.data)
-    daily_values = [float(hourly_values[index]) for index in range(0, len(hourly_values), 24)]
+    hourly_values = [float(value) * capacity for value in ts.data]
 
-    if cadence == "daily":
-        values = daily_values
-        output_resolution = timedelta(days=1)
-    elif cadence == "weekly":
-        if len(daily_values) > 364:
-            values = [sum(daily_values[index : index + 7]) for index in range(0, 51 * 7, 7)]
-            values.append(sum(daily_values[51 * 7 :]))
-        else:
-            values = [sum(daily_values[index : index + 7]) for index in range(0, len(daily_values), 7)]
-        output_resolution = timedelta(days=7)
-    elif cadence == "monthly":
-        values = []
-        year = budget_year if budget_year is not None else ts.initial_timestamp.year
-        day_index = 0
-        while day_index < len(daily_values):
-            for month in range(1, 13):
-                days = monthrange(year, month)[1]
-                month_values = daily_values[day_index : day_index + days]
-                if not month_values:
-                    break
-                values.append(sum(month_values))
-                day_index += len(month_values)
-            year += 1
-        output_resolution = timedelta(days=30)
+    if cadence == "hourly":
+        values = hourly_values
+        output_resolution = timedelta(hours=1)
     else:
-        raise ValueError(f"Unsupported hydro budget resolution: {cadence}")
+        daily_values = [
+            sum(hourly_values[index : index + 24]) / 1000.0 for index in range(0, len(hourly_values), 24)
+        ]
 
-    values = [value / 1000.0 for value in values]
+        if cadence == "daily":
+            values = daily_values
+            output_resolution = timedelta(days=1)
+        elif cadence == "weekly":
+            if len(daily_values) > 364:
+                values = [sum(daily_values[index : index + 7]) for index in range(0, 51 * 7, 7)]
+                values.append(sum(daily_values[51 * 7 :]))
+            else:
+                values = [sum(daily_values[index : index + 7]) for index in range(0, len(daily_values), 7)]
+            output_resolution = timedelta(days=7)
+        elif cadence == "monthly":
+            values = []
+            year = ts.initial_timestamp.year
+            day_index = 0
+            while day_index < len(daily_values):
+                for month in range(1, 13):
+                    days = monthrange(year, month)[1]
+                    month_values = daily_values[day_index : day_index + days]
+                    if not month_values:
+                        break
+                    values.append(sum(month_values))
+                    day_index += len(month_values)
+                year += 1
+            output_resolution = timedelta(days=30)
+        else:
+            raise ValueError(f"Unsupported hydro budget resolution: {cadence}")
 
     return SingleTimeSeries.from_array(
         data=values,
@@ -184,45 +184,59 @@ def attach_time_series_to_generators(context: PluginContext) -> None:
             continue
 
         if name in hydro_generators:
-            cadence = getattr(context.config, "hydro_budget_ts", "hourly")
+            hydro_gen = hydro_generators[name]
+            cadence = getattr(context.config, "hydro_budget_ts", "daily")
             source_keys = context.source_system.list_time_series_keys(source_gen)
             for ts_key in source_keys:
-                if ts_key.name != "hydro_budget":
+                if hydro_gen.is_dispatchable:
+                    if ts_key.name not in {"hydro_budget", "max_active_power"}:
+                        continue
+                elif ts_key.name != "max_active_power":
                     continue
+
+                if ts_key.name == "hydro_budget":
+                    target_name = "hydro_budget"
+                elif hydro_gen.is_dispatchable:
+                    target_name = "max_energy_hour"
+                else:
+                    target_name = "fixed_load"
                 for ts in context.source_system.list_time_series(
                     source_gen,
                     name=ts_key.name,
                     time_series_type=ts_key.time_series_type,
                     **ts_key.features,
                 ):
-                    if cadence == "hourly" and context.target_system.has_time_series(
+                    if ts_key.name != target_name and context.target_system.has_time_series(
                         target_gen,
-                        name=ts.name,
-                        time_series_type=type(ts),
-                        **ts_key.features,
-                    ):
-                        continue
-
-                    if context.target_system.has_time_series(
-                        target_gen,
-                        name=ts.name,
+                        name=ts_key.name,
                         time_series_type=type(ts),
                         **ts_key.features,
                     ):
                         context.target_system.remove_time_series(
                             target_gen,
-                            name=ts.name,
+                            name=ts_key.name,
                             time_series_type=type(ts),
                             **ts_key.features,
                         )
 
-                    solve_year = ts_key.features.get("solve_year")
-                    budget_year = int(solve_year) if solve_year is not None else None
-                    converted_ts = _convert_hydro_budget_time_series(
-                        ts,
-                        cadence,
-                        budget_year=budget_year,
-                    )
+                    if context.target_system.has_time_series(
+                        target_gen,
+                        name=target_name,
+                        time_series_type=type(ts),
+                        **ts_key.features,
+                    ):
+                        context.target_system.remove_time_series(
+                            target_gen,
+                            name=target_name,
+                            time_series_type=type(ts),
+                            **ts_key.features,
+                        )
+
+                    if ts_key.name == "hydro_budget":
+                        converted_ts = _convert_hydro_budget_time_series(ts, cadence, hydro_gen.capacity)
+                    else:
+                        converted_ts = deepcopy(ts)
+                        converted_ts.name = target_name
                     context.target_system.add_time_series(
                         converted_ts,
                         target_gen,

--- a/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/plugin_config.py
+++ b/packages/r2x-reeds-to-plexos/src/r2x_reeds_to_plexos/plugin_config.py
@@ -22,6 +22,6 @@ class ReedsToPlexosConfig(PluginConfig):
         ),
     ]
     hydro_budget_ts: Literal["hourly", "daily", "weekly", "monthly"] = Field(
-        default="hourly",
+        default="daily",
         description="Output resolution for hydro budget time series.",
     )

--- a/packages/r2x-reeds-to-plexos/tests/test_getters.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_getters.py
@@ -205,6 +205,7 @@ def test_basic_getters_return_values(tmp_path):
 
     # Hydro getters
     assert getters.hydro_min_flow(objs["hydro"], context).unwrap() == 0.0
+    assert getters.hydro_max_energy_per_day(objs["hydro"], context).unwrap() == 1e30
 
     # VRE category/resource class
     assert getters.vre_category_with_resource_class(objs["variable"], context).unwrap() == "wind-ons"

--- a/packages/r2x-reeds-to-plexos/tests/test_getters_utils.py
+++ b/packages/r2x-reeds-to-plexos/tests/test_getters_utils.py
@@ -42,14 +42,14 @@ def test_attach_time_series_to_generators(context):
     getters_utils.attach_time_series_to_generators(context)
 
 
-def _hourly_hydro_budget(year: int = 2050, *, timestamp_year: int | None = None) -> SingleTimeSeries:
+def _hourly_hydro_budget(year: int = 2050) -> SingleTimeSeries:
     values: list[float] = []
     for month in range(1, 13):
-        values.extend([float(month)] * monthrange(year, month)[1] * 24)
+        values.extend([float(month) / 100.0] * monthrange(year, month)[1] * 24)
     return SingleTimeSeries.from_array(
         data=values,
         name="hydro_budget",
-        initial_timestamp=datetime(timestamp_year or year, 1, 1),
+        initial_timestamp=datetime(year, 1, 1),
         resolution=timedelta(hours=1),
     )
 
@@ -66,43 +66,60 @@ def _hourly_hydro_budget(year: int = 2050, *, timestamp_year: int | None = None)
 def test_convert_hydro_budget_time_series_resolution(resolution, expected_length, expected_resolution):
     source_ts = _hourly_hydro_budget()
 
-    converted = getters_utils._convert_hydro_budget_time_series(source_ts, resolution)
+    converted = getters_utils._convert_hydro_budget_time_series(source_ts, resolution, 5.0)
 
     assert len(converted.data) == expected_length
     assert converted.resolution == expected_resolution
 
 
-def test_convert_hydro_budget_time_series_converts_mwh_to_gwh():
+def test_convert_hydro_budget_time_series_converts_capacity_factor_to_energy():
     source_ts = _hourly_hydro_budget()
-    expected_total_gwh = sum(float(month) * monthrange(2050, month)[1] for month in range(1, 13)) / 1000.0
+    capacity = 5.0
+    expected_total_gwh = (
+        sum(float(month) / 100.0 * monthrange(2050, month)[1] * 24 for month in range(1, 13))
+        * capacity
+        / 1000.0
+    )
 
-    daily = getters_utils._convert_hydro_budget_time_series(source_ts, "daily")
-    weekly = getters_utils._convert_hydro_budget_time_series(source_ts, "weekly")
-    monthly = getters_utils._convert_hydro_budget_time_series(source_ts, "monthly")
+    hourly = getters_utils._convert_hydro_budget_time_series(source_ts, "hourly", capacity)
+    daily = getters_utils._convert_hydro_budget_time_series(source_ts, "daily", capacity)
+    weekly = getters_utils._convert_hydro_budget_time_series(source_ts, "weekly", capacity)
+    monthly = getters_utils._convert_hydro_budget_time_series(source_ts, "monthly", capacity)
 
-    assert list(monthly.data) == [
-        float(month) * monthrange(2050, month)[1] / 1000.0 for month in range(1, 13)
-    ]
+    assert list(monthly.data) == pytest.approx(
+        [float(month) / 100.0 * monthrange(2050, month)[1] * 24 * capacity / 1000.0 for month in range(1, 13)]
+    )
+    assert hourly.data[0] == pytest.approx(0.05)
     assert sum(daily.data) == pytest.approx(expected_total_gwh)
     assert sum(weekly.data) == pytest.approx(expected_total_gwh)
     assert sum(monthly.data) == pytest.approx(expected_total_gwh)
 
 
-def test_convert_monthly_hydro_budget_uses_solve_year_calendar():
-    source_ts = _hourly_hydro_budget(2050, timestamp_year=2012)
+def test_convert_monthly_hydro_budget_uses_time_series_calendar():
+    source_ts = _hourly_hydro_budget(2012)
 
-    converted = getters_utils._convert_hydro_budget_time_series(
-        source_ts,
-        "monthly",
-        budget_year=2050,
+    converted = getters_utils._convert_hydro_budget_time_series(source_ts, "monthly", 5.0)
+
+    assert list(converted.data) == pytest.approx(
+        [float(month) / 100.0 * monthrange(2012, month)[1] * 24 * 5.0 / 1000.0 for month in range(1, 13)]
     )
 
-    assert list(converted.data) == [
-        float(month) * monthrange(2050, month)[1] / 1000.0 for month in range(1, 13)
-    ]
+
+def test_convert_hydro_budget_time_series_rejects_non_hourly_series():
+    source_ts = SingleTimeSeries.from_array(
+        data=[0.5] * 365,
+        name="hydro_budget",
+        initial_timestamp=datetime(2050, 1, 1),
+        resolution=timedelta(days=1),
+    )
+
+    with pytest.raises(ValueError, match="must be an hourly SingleTimeSeries"):
+        getters_utils._convert_hydro_budget_time_series(source_ts, "daily", 5.0)
 
 
 def test_reeds_to_plexos_config_validates_hydro_budget_resolution():
+    assert ReedsToPlexosConfig().hydro_budget_ts == "daily"
+
     for resolution in ("hourly", "daily", "weekly", "monthly"):
         assert ReedsToPlexosConfig(hydro_budget_ts=resolution).hydro_budget_ts == resolution
 
@@ -136,6 +153,71 @@ def test_attach_time_series_to_generators_applies_hydro_budget_resolution(contex
     assert len(attached) == 1
     assert len(attached[0].data) == 12
     assert attached[0].resolution == timedelta(days=30)
+
+
+def test_attach_time_series_to_generators_maps_hydro_profiles(context):
+    from r2x_reeds.models.components import ReEDSHydroGenerator
+
+    region = ReEDSRegion(name="R1", transmission_region="Z1")
+    dispatchable = ReEDSHydroGenerator(
+        name="HYDRO_D",
+        region=region,
+        technology="hyded",
+        capacity=10.0,
+        is_dispatchable=True,
+    )
+    nondispatchable = ReEDSHydroGenerator(
+        name="HYDRO_ND",
+        region=region,
+        technology="hydnd",
+        capacity=8.0,
+        is_dispatchable=False,
+    )
+    context.source_system.add_component(region)
+    context.source_system.add_component(dispatchable)
+    context.source_system.add_component(nondispatchable)
+    dispatchable_target = PLEXOSGenerator(name="HYDRO_D")
+    nondispatchable_target = PLEXOSGenerator(name="HYDRO_ND")
+    context.target_system.add_component(dispatchable_target)
+    context.target_system.add_component(nondispatchable_target)
+
+    budget = _hourly_hydro_budget()
+    power = SingleTimeSeries.from_array(
+        data=[4.0] * 8760,
+        name="max_active_power",
+        initial_timestamp=datetime(2050, 1, 1),
+        resolution=timedelta(hours=1),
+    )
+    context.source_system.add_time_series(budget, dispatchable, solve_year=2050)
+    context.source_system.add_time_series(power, dispatchable, solve_year=2050)
+    context.source_system.add_time_series(power.model_copy(deep=True), nondispatchable, solve_year=2050)
+    context.target_system.add_time_series(power.model_copy(deep=True), dispatchable_target, solve_year=2050)
+    context.target_system.add_time_series(
+        power.model_copy(deep=True), nondispatchable_target, solve_year=2050
+    )
+    context.config = ReedsToPlexosConfig()
+
+    getters_utils.attach_time_series_to_generators(context)
+
+    dispatchable_budget = context.target_system.list_time_series(
+        dispatchable_target, name="hydro_budget", solve_year=2050
+    )
+    dispatchable_limit = context.target_system.list_time_series(
+        dispatchable_target, name="max_energy_hour", solve_year=2050
+    )
+    nondispatchable_output = context.target_system.list_time_series(
+        nondispatchable_target, name="fixed_load", solve_year=2050
+    )
+    assert len(dispatchable_budget) == 1
+    assert dispatchable_budget[0].resolution == timedelta(days=1)
+    assert list(dispatchable_limit[0].data) == list(power.data)
+    assert list(nondispatchable_output[0].data) == list(power.data)
+    assert not context.target_system.has_time_series(
+        dispatchable_target, name="max_active_power", solve_year=2050
+    )
+    assert not context.target_system.has_time_series(
+        nondispatchable_target, name="max_active_power", solve_year=2050
+    )
 
 
 def test_attach_time_series_to_purchasers(context, monkeypatch):


### PR DESCRIPTION
ReEDS represents dispatchable hydro using an energy budget and an hourly availability limit, while nondispatchable hydro follows a fixed generation profile.

This PR preserves those operating modes in PLEXOS. Dispatchable hydro receives a capacity-scaled energy budget at the configured resolution and an hourly `Max Energy Hour` profile, while nondispatchable hydro receives a `Fixed Load` profile. The default budget resolution is daily and the scalar daily energy limit remains unrestricted when the timeseries provides the constraint.