### PR TITLE
fix: Fix ReEDS-Sienna natural unit serialization

### DIFF
--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -31,11 +31,11 @@
     },
     "field_map": {
       "name": "name",
-      "uuid": "uuid",
-      "peak_active_power": "max_active_power"
+      "uuid": "uuid"
     },
     "getters": {
-      "category": "get_area_category"
+      "category": "get_area_category",
+      "peak_active_power": "get_area_peak_active_power"
     },
     "source_type": "ReEDSRegion",
     "target_type": "Area",
@@ -230,7 +230,7 @@
       "services": "get_gen_services",
       "reactive_power": "get_zero_reactive_power",
       "rating": "hydro_rating",
-      "base_power": "hydro_rating",
+      "base_power": "hydro_base_power",
       "active_power_limits": "hydro_active_power_limits",
       "operation_cost": "hydro_operation_cost",
       "prime_mover_type": "get_hydro_prime_mover",
@@ -261,8 +261,8 @@
       "bus": "get_bus_for_region",
       "services": "get_gen_services",
       "rating": "storage_rating",
-      "base_power": "storage_rating",
-      "storage_capacity": "storage_capacity_mwh",
+      "base_power": "storage_base_power",
+      "storage_capacity": "storage_capacity_device_base",
       "storage_level_limits": "storage_level_limits",
       "initial_storage_capacity_level": "storage_initial_level",
       "input_active_power_limits": "storage_power_limits",

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -81,6 +81,23 @@ def _target_system(context: PluginContext) -> Any:
     return cast(Any, context.target_system)
 
 
+def _system_base_power(context: PluginContext) -> float:
+    return float(_target_system(context).base_power)
+
+
+def _to_system_base(value: float | int, context: PluginContext) -> float:
+    """Convert a natural-unit power value to the Sienna system base."""
+    return float(value) / _system_base_power(context)
+
+
+def _to_device_base(value: float | int, base_power: float | int) -> float:
+    """Convert a natural-unit power or energy value to a device base."""
+    base = float(base_power)
+    if base <= 0.0:
+        return 0.0
+    return float(value) / base
+
+
 def _lookup_area(context: PluginContext, name: str | None) -> Area | None:
     """Helper to find a target Area by name."""
     from r2x_sienna.models import Area
@@ -184,7 +201,7 @@ def get_line_conductance(
 def get_line_rating(component: ReEDSTransmissionLine, context: PluginContext):
     """Use max_active_power.from_to as the line rating."""
     try:
-        return Ok(component.max_active_power.from_to)
+        return Ok(_to_system_base(component.max_active_power.from_to, context))
     except Exception as e:
         return Err(ValueError(f"Could not get line rating: {e}"))
 
@@ -193,7 +210,12 @@ def get_line_rating(component: ReEDSTransmissionLine, context: PluginContext):
 def get_monitored_line_rating(component: ReEDSTransmissionLine, context: PluginContext):
     """Use the larger directional limit as the line rating."""
     try:
-        return Ok(max(component.max_active_power.from_to, component.max_active_power.to_from))
+        return Ok(
+            _to_system_base(
+                max(component.max_active_power.from_to, component.max_active_power.to_from),
+                context,
+            )
+        )
     except Exception as e:
         return Err(ValueError(f"Could not get line rating: {e}"))
 
@@ -211,8 +233,8 @@ def get_line_flow_limits(
     try:
         return Ok(
             FromTo_ToFrom(
-                from_to=component.max_active_power.to_from,
-                to_from=component.max_active_power.from_to,
+                from_to=_to_system_base(component.max_active_power.to_from, context),
+                to_from=_to_system_base(component.max_active_power.from_to, context),
             )
         )
     except Exception as e:
@@ -227,7 +249,12 @@ def get_hvdc_active_power_limits_from(
     try:
         forward = component.max_active_power.to_from
         backward = component.max_active_power.from_to
-        return Ok(MinMax(min=-backward, max=forward))
+        return Ok(
+            MinMax(
+                min=_to_system_base(-backward, context),
+                max=_to_system_base(forward, context),
+            )
+        )
     except Exception as e:
         return Err(ValueError(f"Could not get HVDC from-terminal limits: {e}"))
 
@@ -240,7 +267,12 @@ def get_hvdc_active_power_limits_to(
     try:
         forward = component.max_active_power.to_from
         backward = component.max_active_power.from_to
-        return Ok(MinMax(min=-forward, max=backward))
+        return Ok(
+            MinMax(
+                min=_to_system_base(-forward, context),
+                max=_to_system_base(backward, context),
+            )
+        )
     except Exception as e:
         return Err(ValueError(f"Could not get HVDC to-terminal limits: {e}"))
 
@@ -263,7 +295,7 @@ def get_hvdc_loss(component: ReEDSTransmissionLine, context: PluginContext):
 def get_line_active_power_flow(component: ReEDSTransmissionLine, context: PluginContext):
     """Use max_active_power.from_to as the active power flow."""
     try:
-        return Ok(component.max_active_power.from_to)
+        return Ok(_to_system_base(component.max_active_power.from_to, context))
     except Exception as e:
         return Err(ValueError(f"Could not get active_power_flow: {e}"))
 
@@ -271,7 +303,8 @@ def get_line_active_power_flow(component: ReEDSTransmissionLine, context: Plugin
 @getter
 def get_line_reactive_power_flow(component: ReEDSTransmissionLine, context: PluginContext):
     """Return reactive_power_flow or 0.0 if not available."""
-    return Ok(float(getattr(component, "reactive_power_flow", 0.0) or 0.0))
+    value = float(getattr(component, "reactive_power_flow", 0.0) or 0.0)
+    return Ok(_to_system_base(value, context))
 
 
 @getter
@@ -336,22 +369,17 @@ def get_arc_for_line(component: ReEDSTransmissionLine, context: PluginContext):
 def get_capacity_as_rating(
     component: ReEDSThermalGenerator | ReEDSVariableGenerator, context: PluginContext
 ) -> Result[float | int, ValueError]:
-    """Map ReEDS capacity (MW) to Sienna rating/base_power fields."""
-    capacity = getattr(component, "capacity", None)
-    if capacity is None:
-        return _ok_num(0.0)
-    return _ok_num(float(capacity))
+    """Return the ReEDS capacity as a rating on the device base."""
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+    return _ok_num(_to_device_base(capacity, capacity))
 
 
 @getter
 def get_capacity_as_base_power(
     component: ReEDSThermalGenerator | ReEDSVariableGenerator, context: PluginContext
 ) -> Result[float | int, ValueError]:
-    """Alias to reuse rating getter for base_power."""
-    capacity = getattr(component, "capacity", None)
-    if capacity is None:
-        return _ok_num(0.0)
-    return _ok_num(float(capacity))
+    """Use ReEDS capacity in MW as the device base power."""
+    return _ok_num(float(getattr(component, "capacity", 0.0) or 0.0))
 
 
 @getter
@@ -372,7 +400,12 @@ def get_active_power_limits(
         technology = getattr(component, "technology", "")
         default_frac = _get_defaults(technology, "min_stable_level_percentage")
         min_mw = default_frac * capacity
-    return Ok(MinMax(min=min_mw, max=capacity))
+    return Ok(
+        MinMax(
+            min=_to_device_base(min_mw, capacity),
+            max=_to_device_base(capacity, capacity),
+        )
+    )
 
 
 @getter
@@ -481,8 +514,11 @@ def get_hydro_prime_mover(
 
 @getter
 def get_load_base_power(component: ReEDSDemand, context: PluginContext) -> Result[float | int, ValueError]:
-    """Return a default load base power of 100.0 MVA."""
-    return _ok_num(100.0)
+    """Use peak demand in MW as the load device base power."""
+    demand = float(getattr(component, "max_active_power", 0.0) or 0.0)
+    if demand > 0.0:
+        return _ok_num(demand)
+    return _ok_num(_system_base_power(context))
 
 
 @getter
@@ -490,17 +526,17 @@ def get_consuming_tech_max_active_power(
     component: ReEDSElectrolyzerDemand | ReEDSDataCenterDemand | ReEDSSteamMethaneReformingDemand,
     context: PluginContext,
 ) -> Result[float | int, ValueError]:
-    """Return max_active_power for consuming technologies.
+    """Return max_active_power on the device base for consuming technologies.
 
     Prefers an explicit ``max_active_power`` field when set, then falls back to
     ``capacity``, and finally returns 0.0 if neither is available.
     """
+    base_power = float(getattr(component, "capacity", 0.0) or 0.0)
     max_ap = getattr(component, "max_active_power", None)
     if max_ap is not None:
-        return _ok_num(float(max_ap))
-    capacity = getattr(component, "capacity", None)
-    if capacity is not None:
-        return _ok_num(float(capacity))
+        return _ok_num(_to_device_base(float(max_ap), base_power))
+    if base_power > 0.0:
+        return _ok_num(1.0)
     return _ok_num(0.0)
 
 
@@ -549,11 +585,9 @@ def get_thermal_active_power(
     component: ReEDSThermalGenerator,
     context: PluginContext,
 ) -> Result[float | int, ValueError]:
-    """Return the generator capacity as initial active power dispatch."""
-    capacity = getattr(component, "capacity", None)
-    if capacity is None:
-        return _ok_num(0.0)
-    return _ok_num(float(capacity))
+    """Return full capacity as initial dispatch on the device base."""
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+    return _ok_num(_to_device_base(capacity, capacity))
 
 
 @getter
@@ -600,7 +634,7 @@ def get_default_time_at_status(
 def thermal_ramp_limits(
     component: ReEDSThermalGenerator, context: PluginContext
 ) -> Result[UpDown | None, ValueError]:
-    """Convert ramp_rate (fraction/hour) to MW/min for Sienna ramp_limits.
+    """Convert ramp_rate (fraction/hour) to per-unit/min for Sienna ramp_limits.
 
     Falls back to ``max_ramp_up_percentage`` from defaults.json (fraction of capacity
     per hour) when the source field is not populated. Returns None only if both the
@@ -614,7 +648,8 @@ def thermal_ramp_limits(
         if not ramp_rate:
             return Ok(None)
     ramp_mw_per_min = float(ramp_rate) * capacity / 60.0
-    return Ok(UpDown(up=ramp_mw_per_min, down=ramp_mw_per_min))
+    ramp_per_unit_per_min = _to_device_base(ramp_mw_per_min, capacity)
+    return Ok(UpDown(up=ramp_per_unit_per_min, down=ramp_per_unit_per_min))
 
 
 @getter
@@ -820,6 +855,15 @@ def get_area_category(component: ReEDSRegion, context: PluginContext) -> Result[
 
 
 @getter
+def get_area_peak_active_power(
+    component: ReEDSRegion, context: PluginContext
+) -> Result[float | int, ValueError]:
+    """Return peak active power on the system base."""
+    peak = float(getattr(component, "max_active_power", 0.0) or 0.0)
+    return _ok_num(_to_system_base(peak, context))
+
+
+@getter
 def base_voltage_default(component: ReEDSRegion, context: PluginContext) -> Result[float | int, ValueError]:
     """Provide default base voltage in kV."""
     return _ok_num(float(ureg.Quantity(115.0, "kV").magnitude))  # magnitude only to avoid unit issues
@@ -847,8 +891,11 @@ def bustype_default(component: ReEDSRegion, context: PluginContext) -> Result[AC
 def demand_max_active_power(
     component: ReEDSDemand, context: PluginContext
 ) -> Result[float | int, ValueError]:
-    """Return demand max active power."""
-    return _ok_num(float(getattr(component, "max_active_power", 0.0) or 0.0))
+    """Return maximum demand on the load device base."""
+    demand = float(getattr(component, "max_active_power", 0.0) or 0.0)
+    if demand > 0.0:
+        return _ok_num(_to_device_base(demand, demand))
+    return _ok_num(0.0)
 
 
 @getter
@@ -861,7 +908,16 @@ def demand_max_reactive_power(
 
 @getter
 def hydro_rating(component: ReEDSHydroGenerator, context: PluginContext) -> Result[float | int, ValueError]:
-    """Map capacity to rating/base_power."""
+    """Return the ReEDS hydro capacity as a rating on the device base."""
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+    return _ok_num(_to_device_base(capacity, capacity))
+
+
+@getter
+def hydro_base_power(
+    component: ReEDSHydroGenerator, context: PluginContext
+) -> Result[float | int, ValueError]:
+    """Use ReEDS hydro capacity in MW as the device base power."""
     return _ok_num(float(getattr(component, "capacity", 0.0) or 0.0))
 
 
@@ -871,12 +927,12 @@ def hydro_active_power_limits(
 ) -> Result[MinMax, ValueError]:
     """Min/max active power limits for hydro."""
     cap = float(getattr(component, "capacity", 0.0) or 0.0)
-    return Ok(MinMax(min=0.0, max=cap))
+    return Ok(MinMax(min=0.0, max=_to_device_base(cap, cap)))
 
 
 @getter
 def hydro_ramp_limits(component: ReEDSHydroGenerator, context: PluginContext) -> Result[UpDown, ValueError]:
-    """Convert ramp_rate (fraction/hour) to MW/min for Sienna ramp_limits.
+    """Convert ramp_rate (fraction/hour) to per-unit/min for Sienna ramp_limits.
 
     Falls back to ``max_ramp_up_percentage`` from defaults.json when the source
     field is not populated.
@@ -886,7 +942,7 @@ def hydro_ramp_limits(component: ReEDSHydroGenerator, context: PluginContext) ->
     if ramp_rate is None:
         technology = getattr(component, "technology", "")
         ramp_rate = _get_defaults(technology, "max_ramp_up_percentage") or 0.0
-    ramp_limit = cap * float(ramp_rate) / 60.0
+    ramp_limit = _to_device_base(cap * float(ramp_rate) / 60.0, cap)
     return Ok(UpDown(up=ramp_limit, down=ramp_limit))
 
 
@@ -919,19 +975,28 @@ def hydro_operation_cost(
 
 @getter
 def storage_rating(component: ReEDSStorage, context: PluginContext) -> Result[float | int, ValueError]:
-    """Use capacity as rating/base power for storage."""
+    """Return the storage rating on its device base."""
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+    return _ok_num(1.0 if capacity > 0.0 else 0.0)
+
+
+@getter
+def storage_base_power(component: ReEDSStorage, context: PluginContext) -> Result[float | int, ValueError]:
+    """Use storage capacity in MW as its device base power."""
     return _ok_num(float(getattr(component, "capacity", 0.0) or 0.0))
 
 
 @getter
-def storage_capacity_mwh(component: ReEDSStorage, context: PluginContext) -> Result[float | int, ValueError]:
-    """Energy capacity from explicit value or duration * power."""
+def storage_capacity_device_base(
+    component: ReEDSStorage, context: PluginContext
+) -> Result[float | int, ValueError]:
+    """Return storage energy capacity on the device base."""
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
     energy = getattr(component, "energy_capacity", None)
     if energy is not None:
-        return _ok_num(float(energy))
-    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+        return _ok_num(_to_device_base(float(energy), capacity))
     duration = float(getattr(component, "storage_duration", 0.0) or 0.0)
-    return _ok_num(capacity * duration)
+    return _ok_num(duration)
 
 
 @getter
@@ -942,9 +1007,9 @@ def storage_level_limits(component: ReEDSStorage, context: PluginContext) -> Res
 
 @getter
 def storage_power_limits(component: ReEDSStorage, context: PluginContext) -> Result[MinMax, ValueError]:
-    """Charge/discharge limits from capacity."""
+    """Return charge and discharge limits on the device base."""
     cap = float(getattr(component, "capacity", 0.0) or 0.0)
-    return Ok(MinMax(min=0.0, max=cap))
+    return Ok(MinMax(min=0.0, max=1.0 if cap > 0.0 else 0.0))
 
 
 @getter
@@ -991,8 +1056,9 @@ def storage_conversion_factor(
 def consuming_capacity_as_max_power(
     component: ReEDSConsumingTechnology, context: PluginContext
 ) -> Result[float | int, ValueError]:
-    """Return the consuming technology capacity (MW) as max_active_power."""
-    return _ok_num(float(getattr(component, "capacity", 0.0) or 0.0))
+    """Return consuming capacity as maximum power on the device base."""
+    capacity = float(getattr(component, "capacity", 0.0) or 0.0)
+    return _ok_num(_to_device_base(capacity, capacity))
 
 
 @getter

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/translation.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/translation.py
@@ -42,7 +42,12 @@ def reeds_to_sienna(system: System, config: ReEDSToSiennaConfig) -> System:
         permanent=True,
     )
 
-    sienna_system = System(name="Sienna", auto_add_composed_components=True, time_series_manager=ts_manager)
+    sienna_system = System(
+        name="Sienna",
+        system_base=100.0,
+        auto_add_composed_components=True,
+        time_series_manager=ts_manager,
+    )
     context.target_system = sienna_system
 
     apply_rules_to_context(context)

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from infrasys.cost_curves import FuelCurve, LinearCurve
 from r2x_reeds.models import (
+    ReEDSConsumingTechnology,
     ReEDSDataCenterDemand,
     ReEDSDemand,
     ReEDSElectrolyzerDemand,
@@ -38,7 +39,7 @@ def test_basic_getters_return_values(tmp_path) -> None:
 
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
     context.source_system.add_component(region)
@@ -140,11 +141,16 @@ def test_basic_getters_return_values(tmp_path) -> None:
 
     # Test thermal generator getters
     assert getters.unique_component_name(thermal, context).unwrap() == "p1_THERM"
-    assert getters.get_capacity_as_rating(thermal, context).unwrap() == 10.0
+    assert getters.get_capacity_as_rating(thermal, context).unwrap() == 1.0
     assert getters.get_capacity_as_base_power(thermal, context).unwrap() == 10.0
     limits = getters.get_active_power_limits(thermal, context).unwrap()
-    assert limits.max == 10.0
-    assert limits.min == pytest.approx(0.4 * 10.0)  # min_stable_level_percentage from defaults.json
+    assert limits.max == 1.0
+    assert limits.min == pytest.approx(0.4)  # min_stable_level_percentage from defaults.json
+    assert getters.get_thermal_active_power(thermal, context).unwrap() == 1.0
+    thermal_ramp_limits = getters.thermal_ramp_limits(thermal, context).unwrap()
+    assert thermal_ramp_limits is not None
+    assert thermal_ramp_limits.up == pytest.approx(0.02 / 60.0)
+    assert thermal_ramp_limits.down == pytest.approx(0.02 / 60.0)
     assert getters.get_thermal_operation_cost(thermal, context).unwrap() is not None
     assert getters.get_prime_mover(thermal, context).unwrap() == PrimeMoversType.ST
     assert getters.get_fuel_enum(thermal, context).unwrap() == ThermalFuels.COAL
@@ -170,47 +176,51 @@ def test_basic_getters_return_values(tmp_path) -> None:
     assert getters.get_area_category(region, context).unwrap() == "region"
 
     # Test demand getters
-    assert getters.demand_max_active_power(demand, context).unwrap() == 3.0
+    assert getters.demand_max_active_power(demand, context).unwrap() == 1.0
     assert getters.demand_max_reactive_power(demand, context).unwrap() == 0.0
-    assert getters.get_load_base_power(demand, context).unwrap() == 100.0
+    assert getters.get_load_base_power(demand, context).unwrap() == 3.0
 
     # Test transmission line getters
-    assert getters.get_monitored_line_rating(line, context).unwrap() == 100.0
-    assert getters.get_line_flow_limits(line, context).unwrap().from_to == 100.0
-    assert getters.get_line_flow_limits(line, context).unwrap().to_from == 100.0
+    assert getters.get_monitored_line_rating(line, context).unwrap() == 1.0
+    assert getters.get_line_flow_limits(line, context).unwrap().from_to == 1.0
+    assert getters.get_line_flow_limits(line, context).unwrap().to_from == 1.0
 
     hvdc_limits_from = getters.get_hvdc_active_power_limits_from(hvdc_line, context).unwrap()
-    assert hvdc_limits_from.min == -80.0
-    assert hvdc_limits_from.max == 100.0
+    assert hvdc_limits_from.min == -0.8
+    assert hvdc_limits_from.max == 1.0
     hvdc_limits_to = getters.get_hvdc_active_power_limits_to(hvdc_line, context).unwrap()
-    assert hvdc_limits_to.min == -100.0
-    assert hvdc_limits_to.max == 80.0
+    assert hvdc_limits_to.min == -1.0
+    assert hvdc_limits_to.max == 0.8
     reactive_limits = getters.get_hvdc_reactive_power_limits(hvdc_line, context).unwrap()
     assert reactive_limits.min == 0.0
     assert reactive_limits.max == 0.0
     assert getters.get_hvdc_loss(hvdc_line, context).unwrap().function_data.proportional_term == 0.03
 
     # Test hydro getters
-    assert getters.hydro_rating(hydro, context).unwrap() == 8.0
+    assert getters.hydro_rating(hydro, context).unwrap() == 1.0
+    assert getters.hydro_base_power(hydro, context).unwrap() == 8.0
     assert getters.hydro_operation_cost(hydro, context).unwrap() is not None
     hydro_limits = getters.hydro_active_power_limits(hydro, context).unwrap()
-    assert hydro_limits.max == 8.0
+    assert hydro_limits.max == 1.0
     assert hydro_limits.min == 0.0
     ramp_limits = getters.hydro_ramp_limits(hydro, context).unwrap()
-    assert ramp_limits.up == pytest.approx(8.0 * 10.0 / 60.0)  # cap * rate / 60
-    assert ramp_limits.down == pytest.approx(8.0 * 10.0 / 60.0)
+    assert ramp_limits.up == pytest.approx(10.0 / 60.0)
+    assert ramp_limits.down == pytest.approx(10.0 / 60.0)
     time_limits = getters.hydro_time_limits(hydro, context).unwrap()
     assert time_limits.up == 0.0
     assert time_limits.down == 0.0
 
     # Test storage getters
-    assert getters.storage_rating(storage, context).unwrap() == 4.0
-    assert getters.storage_capacity_mwh(storage, context).unwrap() == 8.0
+    assert getters.storage_rating(storage, context).unwrap() == 1.0
+    assert getters.storage_base_power(storage, context).unwrap() == 4.0
+    assert getters.storage_capacity_device_base(storage, context).unwrap() == 2.0
+    storage_with_energy = storage.model_copy(update={"energy_capacity": 10.0})
+    assert getters.storage_capacity_device_base(storage_with_energy, context).unwrap() == 2.5
     storage_limits = getters.storage_level_limits(storage, context).unwrap()
     assert storage_limits.min == 0.0
     assert storage_limits.max == 1.0
     power_limits = getters.storage_power_limits(storage, context).unwrap()
-    assert power_limits.max == 4.0
+    assert power_limits.max == 1.0
     efficiency = getters.storage_efficiency(storage, context).unwrap()
     assert efficiency.input == pytest.approx(0.9)
     assert efficiency.output == pytest.approx(1.0)
@@ -242,8 +252,8 @@ def test_basic_getters_return_values(tmp_path) -> None:
     assert getters.get_reserve_deployed_fraction(reserve, context).unwrap() == 1.0
 
     # Test line getters
-    assert getters.get_line_rating(line, context).unwrap() == 100.0
-    assert getters.get_line_active_power_flow(line, context).unwrap() == 100.0
+    assert getters.get_line_rating(line, context).unwrap() == 1.0
+    assert getters.get_line_active_power_flow(line, context).unwrap() == 1.0
     assert getters.get_line_reactive_power_flow(line, context).unwrap() == 0.0
     assert getters.get_line_resistance(line, context).unwrap() == 0.0
     assert getters.get_line_reactance(line, context).unwrap() == 0.0
@@ -268,7 +278,7 @@ def test_unique_component_name_collision(tmp_path) -> None:
 
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
     area = Area(name="p1", category="region")
@@ -319,7 +329,7 @@ def test_bus_number_with_z_prefix(tmp_path) -> None:
     """Test bus number extraction for z-prefixed regions."""
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="z122")
     result = getters.get_bus_number(region, context).unwrap()
@@ -337,7 +347,7 @@ def test_get_gen_services_all_generator_types(tmp_path) -> None:
 
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
     area = Area(name="p1", category="region")
@@ -434,7 +444,7 @@ def test_get_gen_services_resolves_non_spinning_reserve(tmp_path) -> None:
 
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
     area = Area(name="p1", category="region")
@@ -524,7 +534,7 @@ def test_get_hydro_prime_mover(tmp_path) -> None:
     """get_hydro_prime_mover must always return PrimeMoversType.HY."""
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
     hydro = ReEDSHydroGenerator(
@@ -542,7 +552,7 @@ def test_get_zero_reactive_power_limits(tmp_path) -> None:
     """get_zero_reactive_power_limits always returns MinMax(0.0, 0.0) regardless of component type."""
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
 
@@ -567,10 +577,10 @@ def test_get_zero_reactive_power_limits(tmp_path) -> None:
 
 
 def test_consuming_tech_getters(tmp_path) -> None:
-    """get_consuming_tech_max_active_power and get_consuming_tech_base_power work for both consuming tech types."""
+    """Test device-base getters for specific and generic consuming technologies."""
     context = make_context(tmp_path)
     context.source_system = System(name="source")
-    context.target_system = System(name="target")
+    context.target_system = System(name="target", system_base=100.0)
 
     region = ReEDSRegion(name="p1")
 
@@ -590,11 +600,21 @@ def test_consuming_tech_getters(tmp_path) -> None:
         electricity_efficiency=1.0,
         # max_active_power not set — should fall back to capacity
     )
+    consuming_technology = ReEDSConsumingTechnology(
+        name="CONSUMING1",
+        region=region,
+        technology="consume",
+        capacity=20.0,
+        electricity_efficiency=1.0,
+    )
 
     # Electrolyzer: prefers explicit max_active_power
-    assert getters.get_consuming_tech_max_active_power(electrolyzer, context).unwrap() == 40.0
+    assert getters.get_consuming_tech_max_active_power(electrolyzer, context).unwrap() == 0.8
     assert getters.get_consuming_tech_base_power(electrolyzer, context).unwrap() == 50.0
 
     # DataCenter: no explicit max_active_power → uses capacity
-    assert getters.get_consuming_tech_max_active_power(datacenter, context).unwrap() == 30.0
+    assert getters.get_consuming_tech_max_active_power(datacenter, context).unwrap() == 1.0
     assert getters.get_consuming_tech_base_power(datacenter, context).unwrap() == 30.0
+
+    assert getters.consuming_capacity_as_max_power(consuming_technology, context).unwrap() == 1.0
+    assert getters.consuming_capacity_as_base_power(consuming_technology, context).unwrap() == 20.0

--- a/packages/r2x-reeds-to-sienna/tests/test_translation.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation.py
@@ -115,6 +115,7 @@ def test_reeds_to_sienna_returns_system():
 
     assert isinstance(result, System)
     assert result.name == "Sienna"
+    assert result.base_power == 100.0
 
 
 def test_reeds_to_sienna_translates_region_to_bus():

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -28,7 +28,7 @@ def test_reeds_region_translates_to_area(tmp_path) -> None:
     context.source_system.add_component(
         ReEDSRegion(name="R_TEST", category="region-cat", max_active_power=123.0, interconnect="west")
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -39,7 +39,7 @@ def test_reeds_region_translates_to_area(tmp_path) -> None:
     area = areas[0]
     assert area.name == "R_TEST"
     assert area.category == "region-cat"
-    assert pytest.approx(123.0) == area.peak_active_power
+    assert pytest.approx(1.23) == area.peak_active_power
     assert pytest.approx(0.0) == area.peak_reactive_power
     assert pytest.approx(0.0) == area.load_response
 
@@ -51,7 +51,7 @@ def test_reeds_region_translates_to_acbus(tmp_path) -> None:
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
     context.source_system.add_component(ReEDSRegion(name="p42", category="region"))
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -79,7 +79,7 @@ def test_reeds_region_with_non_numeric_name(tmp_path) -> None:
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
     context.source_system.add_component(ReEDSRegion(name="otx", category="region"))
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -132,7 +132,7 @@ def test_reeds_generators_translate_to_sienna_types(tmp_path) -> None:
             capacity=25.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -155,19 +155,22 @@ def test_reeds_generators_translate_to_sienna_types(tmp_path) -> None:
     thermal = thermal_gens[0]
     assert thermal.name == "THERM1"
     assert thermal.category == "gas-cc"
-    assert thermal.rating == 100.0
+    assert thermal.rating == 1.0
+    assert thermal.base_power == 100.0
     assert thermal.bus == buses[0]
 
     wind = vre_dispatch[0]
     assert wind.name == "VRE1"
     assert wind.category == "wind-ons"
-    assert wind.rating == 50.0
+    assert wind.rating == 1.0
+    assert wind.base_power == 50.0
     assert wind.bus == buses[0]
 
     pv = vre_nondispatch[0]
     assert pv.name == "DISTPV"
     assert pv.category == "distpv"
-    assert pv.rating == 25.0
+    assert pv.rating == 1.0
+    assert pv.base_power == 25.0
     assert pv.bus == buses[0]
 
 
@@ -189,7 +192,7 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
             ramp_rate=10.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -201,9 +204,10 @@ def test_reeds_hydro_translates_to_hydro_dispatch(tmp_path) -> None:
     hydro = hydros[0]
     assert hydro.name == "HYDRO1"
     assert hydro.category == "hydro"
-    assert hydro.rating == 100.0
-    assert hydro.active_power_limits.max == 100.0
-    assert hydro.ramp_limits.up == pytest.approx(100.0 * 10.0 / 60.0)  # cap * rate / 60
+    assert hydro.rating == 1.0
+    assert hydro.base_power == 100.0
+    assert hydro.active_power_limits.max == 1.0
+    assert hydro.ramp_limits.up == pytest.approx(10.0 / 60.0)
     assert hydro.time_limits.up == 0.0
     assert hydro.time_limits.down == 0.0
 
@@ -226,7 +230,7 @@ def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:
             round_trip_efficiency=0.85,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -238,8 +242,11 @@ def test_reeds_storage_translates_to_energy_reservoir(tmp_path) -> None:
     storage = storages[0]
     assert storage.name == "BATT1"
     assert storage.category == "battery_4"
-    assert storage.rating == 50.0
-    assert storage.storage_capacity == 200.0  # 50 * 4
+    assert storage.base_power == 50.0
+    assert storage.rating == 1.0
+    assert storage.storage_capacity == 4.0
+    assert storage.input_active_power_limits.max == 1.0
+    assert storage.output_active_power_limits.max == 1.0
     assert storage.efficiency.input == pytest.approx(0.85)
     assert storage.efficiency.output == pytest.approx(1.0)
 
@@ -259,7 +266,7 @@ def test_reeds_demand_translates_to_power_load(tmp_path) -> None:
             max_active_power=500.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -270,8 +277,8 @@ def test_reeds_demand_translates_to_power_load(tmp_path) -> None:
 
     load = loads[0]
     assert load.name == "LOAD1"
-    assert load.max_active_power.magnitude == 500.0
-    assert load.base_power.magnitude == 100.0
+    assert load.max_active_power.magnitude == 1.0
+    assert load.base_power.magnitude == 500.0
 
 
 def test_reeds_interface_translates_to_area_interchange(tmp_path) -> None:
@@ -287,7 +294,7 @@ def test_reeds_interface_translates_to_area_interchange(tmp_path) -> None:
     context.source_system.add_component(
         ReEDSInterface(name="IFACE_1_2", from_region=region1, to_region=region2)
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -318,7 +325,7 @@ def test_reeds_reserve_translates_to_variable_reserve(tmp_path) -> None:
             duration=3600.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -356,7 +363,7 @@ def test_reeds_ac_transmission_line_translates_to_monitored_line(tmp_path) -> No
             max_active_power={"from_to": 125.0, "to_from": 150.0},
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -367,9 +374,9 @@ def test_reeds_ac_transmission_line_translates_to_monitored_line(tmp_path) -> No
 
     line = lines[0]
     assert line.name == "LINE_1_2"
-    assert line.rating == 150.0
-    assert line.flow_limits.from_to == 150.0
-    assert line.flow_limits.to_from == 125.0
+    assert line.rating == 1.5
+    assert line.flow_limits.from_to == 1.5
+    assert line.flow_limits.to_from == 1.25
     assert line.active_power_flow == 0.0
     assert line.rating_b is None
     assert line.rating_c is None
@@ -407,7 +414,7 @@ def test_reeds_vsc_lcc_b2b_transmission_types_translate_to_generic_hvdc_lines(tm
                 **attributes,
             )
         )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -422,10 +429,10 @@ def test_reeds_vsc_lcc_b2b_transmission_types_translate_to_generic_hvdc_lines(tm
     for name, attributes in source_lines.items():
         line = lines_by_name[name]
         assert line.active_power_flow == 0.0
-        assert line.active_power_limits_from.min == -125.0
-        assert line.active_power_limits_from.max == 150.0
-        assert line.active_power_limits_to.min == -150.0
-        assert line.active_power_limits_to.max == 125.0
+        assert line.active_power_limits_from.min == -1.25
+        assert line.active_power_limits_from.max == 1.5
+        assert line.active_power_limits_to.min == -1.5
+        assert line.active_power_limits_to.max == 1.25
         assert line.reactive_power_limits_from.min == 0.0
         assert line.reactive_power_limits_from.max == 0.0
         assert line.reactive_power_limits_to.min == 0.0
@@ -445,7 +452,7 @@ def test_multiple_regions_create_multiple_buses_and_areas(tmp_path) -> None:
     context.source_system.add_component(ReEDSRegion(name="p1", category="region"))
     context.source_system.add_component(ReEDSRegion(name="p2", category="region"))
     context.source_system.add_component(ReEDSRegion(name="p3", category="region"))
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     result = apply_rules_to_context(context)
@@ -483,7 +490,7 @@ def test_reeds_hydro_has_hy_prime_mover(tmp_path) -> None:
             is_dispatchable=True,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -511,7 +518,7 @@ def test_reeds_hydro_has_reactive_power_limits(tmp_path) -> None:
             is_dispatchable=True,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -540,7 +547,7 @@ def test_reeds_non_spinning_reserve_translates_to_variable_reserve_non_spinning(
             duration=1800.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -605,7 +612,7 @@ def test_gen_services_attaches_non_spinning_reserve_to_generator(tmp_path) -> No
         )
     )
 
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -642,7 +649,7 @@ def test_reeds_spinning_reserve_does_not_produce_non_spinning(tmp_path) -> None:
             time_frame=300.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -673,7 +680,7 @@ def test_reeds_electrolyzer_demand_translates_to_interruptible_load(tmp_path) ->
             max_active_power=40.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -684,7 +691,7 @@ def test_reeds_electrolyzer_demand_translates_to_interruptible_load(tmp_path) ->
     load = loads[0]
     assert load.name == "ELEC1"
     assert load.category == "electrolyzer"
-    assert load.max_active_power.magnitude == pytest.approx(40.0)
+    assert load.max_active_power.magnitude == pytest.approx(0.8)
     assert load.base_power.magnitude == pytest.approx(50.0)
 
 
@@ -706,7 +713,7 @@ def test_reeds_datacenter_demand_translates_to_interruptible_load(tmp_path) -> N
             electricity_efficiency=1.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -718,7 +725,7 @@ def test_reeds_datacenter_demand_translates_to_interruptible_load(tmp_path) -> N
     assert load.name == "DC1"
     assert load.category == "data-center"
     # No explicit max_active_power — falls back to capacity
-    assert load.max_active_power.magnitude == pytest.approx(200.0)
+    assert load.max_active_power.magnitude == pytest.approx(1.0)
     assert load.base_power.magnitude == pytest.approx(200.0)
 
 
@@ -750,7 +757,7 @@ def test_reeds_smr_demand_translates_to_interruptible_load(tmp_path) -> None:
             electricity_efficiency=1.0,
         )
     )
-    context.target_system = System(name="target", auto_add_composed_components=True)
+    context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
 
     apply_rules_to_context(context)
@@ -758,8 +765,8 @@ def test_reeds_smr_demand_translates_to_interruptible_load(tmp_path) -> None:
     loads = {load.name: load for load in context.target_system.get_components(InterruptiblePowerLoad)}
     assert set(loads) == {"SMR1", "SMR_CCS1"}
     assert loads["SMR1"].category == "smr"
-    assert loads["SMR1"].max_active_power.magnitude == pytest.approx(40.0)
+    assert loads["SMR1"].max_active_power.magnitude == pytest.approx(0.8)
     assert loads["SMR1"].base_power.magnitude == pytest.approx(50.0)
     assert loads["SMR_CCS1"].category == "smr_ccs"
-    assert loads["SMR_CCS1"].max_active_power.magnitude == pytest.approx(30.0)
+    assert loads["SMR_CCS1"].max_active_power.magnitude == pytest.approx(1.0)
     assert loads["SMR_CCS1"].base_power.magnitude == pytest.approx(30.0)


### PR DESCRIPTION
ReEDS provides component capacities and limits in MW and MWh while PowerSystems stores many static device properties on either the system base or the component device base. The `r2x-reeds-to-sienna` translator previously wrote several natural unit values directly into these per unit fields, which caused incorrect values after the system was deserialized and evaluated in PowerSystems.

This PR applies the appropriate system-base and device-base conversions for all components. 