### PR TITLE
fix: ReEDS consuming technology mapping in Sienna

### DIFF
--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/config/rules.json
@@ -426,7 +426,17 @@
   {
     "name": "electrolyzer_load",
     "defaults": {
-      "category": "electrolyzer"
+      "category": "electrolyzer",
+      "constant_reactive_power": 0.0,
+      "impedance_active_power": 0.0,
+      "impedance_reactive_power": 0.0,
+      "current_active_power": 0.0,
+      "current_reactive_power": 0.0,
+      "max_constant_reactive_power": 0.0,
+      "max_impedance_active_power": 0.0,
+      "max_impedance_reactive_power": 0.0,
+      "max_current_active_power": 0.0,
+      "max_current_reactive_power": 0.0
     },
     "field_map": {
       "name": "name",
@@ -435,19 +445,30 @@
     },
     "getters": {
       "bus": "get_bus_for_region",
-      "max_active_power": "get_consuming_tech_max_active_power",
+      "constant_active_power": "get_consuming_tech_max_active_power",
+      "max_constant_active_power": "get_consuming_tech_max_active_power",
       "base_power": "get_consuming_tech_base_power",
       "ext": "get_component_ext"
     },
     "depends_on": ["region_bus"],
     "source_type": "ReEDSElectrolyzerDemand",
-    "target_type": "InterruptiblePowerLoad",
+    "target_type": "StandardLoad",
     "version": 1
   },
   {
     "name": "datacenter_load",
     "defaults": {
-      "category": "data-center"
+      "category": "data-center",
+      "constant_reactive_power": 0.0,
+      "impedance_active_power": 0.0,
+      "impedance_reactive_power": 0.0,
+      "current_active_power": 0.0,
+      "current_reactive_power": 0.0,
+      "max_constant_reactive_power": 0.0,
+      "max_impedance_active_power": 0.0,
+      "max_impedance_reactive_power": 0.0,
+      "max_current_active_power": 0.0,
+      "max_current_reactive_power": 0.0
     },
     "field_map": {
       "name": "name",
@@ -456,19 +477,30 @@
     },
     "getters": {
       "bus": "get_bus_for_region",
-      "max_active_power": "get_consuming_tech_max_active_power",
+      "constant_active_power": "get_consuming_tech_max_active_power",
+      "max_constant_active_power": "get_consuming_tech_max_active_power",
       "base_power": "get_consuming_tech_base_power",
       "ext": "get_component_ext"
     },
     "depends_on": ["region_bus"],
     "source_type": "ReEDSDataCenterDemand",
-    "target_type": "InterruptiblePowerLoad",
+    "target_type": "StandardLoad",
     "version": 1
   },
   {
     "name": "smr_load",
     "defaults": {
-      "category": "smr"
+      "category": "smr",
+      "constant_reactive_power": 0.0,
+      "impedance_active_power": 0.0,
+      "impedance_reactive_power": 0.0,
+      "current_active_power": 0.0,
+      "current_reactive_power": 0.0,
+      "max_constant_reactive_power": 0.0,
+      "max_impedance_active_power": 0.0,
+      "max_impedance_reactive_power": 0.0,
+      "max_current_active_power": 0.0,
+      "max_current_reactive_power": 0.0
     },
     "field_map": {
       "name": "name",
@@ -477,21 +509,30 @@
     },
     "getters": {
       "bus": "get_bus_for_region",
-      "max_active_power": "get_consuming_tech_max_active_power",
+      "constant_active_power": "get_consuming_tech_max_active_power",
+      "max_constant_active_power": "get_consuming_tech_max_active_power",
       "base_power": "get_consuming_tech_base_power",
       "ext": "get_component_ext"
     },
     "depends_on": ["region_bus"],
     "source_type": "ReEDSSteamMethaneReformingDemand",
-    "target_type": "InterruptiblePowerLoad",
+    "target_type": "StandardLoad",
     "version": 1
   },
   {
     "name": "consuming_tech_load",
     "defaults": {
       "category": "consuming-tech",
-      "active_power": 0.0,
-      "reactive_power": 0.0
+      "constant_reactive_power": 0.0,
+      "impedance_active_power": 0.0,
+      "impedance_reactive_power": 0.0,
+      "current_active_power": 0.0,
+      "current_reactive_power": 0.0,
+      "max_constant_reactive_power": 0.0,
+      "max_impedance_active_power": 0.0,
+      "max_impedance_reactive_power": 0.0,
+      "max_current_active_power": 0.0,
+      "max_current_reactive_power": 0.0
     },
     "field_map": {
       "name": "name",
@@ -506,16 +547,14 @@
     },
     "getters": {
       "bus": "get_bus_for_region",
-      "active_power": "get_zero_active_power",
-      "reactive_power": "get_zero_reactive_power",
-      "max_active_power": "consuming_capacity_as_max_power",
-      "max_reactive_power": "demand_max_reactive_power",
+      "constant_active_power": "consuming_capacity_as_max_power",
+      "max_constant_active_power": "consuming_capacity_as_max_power",
       "base_power": "consuming_capacity_as_base_power",
       "ext": "get_component_ext"
     },
     "depends_on": ["region_bus"],
     "source_type": "ReEDSConsumingTechnology",
-    "target_type": "InterruptiblePowerLoad",
+    "target_type": "StandardLoad",
     "version": 1
   }
 ]

--- a/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_rules_loading.py
@@ -212,27 +212,30 @@ def test_spinning_reserve_rule_has_non_spinning_exclusion_filter() -> None:
 
 
 def test_has_consuming_technology_rules() -> None:
-    """Verify consuming technology types map to InterruptiblePowerLoad."""
+    """Verify consuming technology types map to StandardLoad."""
     rules_path = files("r2x_reeds_to_sienna.config") / "rules.json"
     rules_data = json.loads(rules_path.read_text())
 
     assert any(
-        rule.get("source_type") == "ReEDSElectrolyzerDemand"
-        and rule.get("target_type") == "InterruptiblePowerLoad"
+        rule.get("source_type") == "ReEDSElectrolyzerDemand" and rule.get("target_type") == "StandardLoad"
         for rule in rules_data
-    ), "Missing ReEDSElectrolyzerDemand -> InterruptiblePowerLoad rule"
+    ), "Missing ReEDSElectrolyzerDemand -> StandardLoad rule"
 
     assert any(
-        rule.get("source_type") == "ReEDSDataCenterDemand"
-        and rule.get("target_type") == "InterruptiblePowerLoad"
+        rule.get("source_type") == "ReEDSDataCenterDemand" and rule.get("target_type") == "StandardLoad"
         for rule in rules_data
-    ), "Missing ReEDSDataCenterDemand -> InterruptiblePowerLoad rule"
+    ), "Missing ReEDSDataCenterDemand -> StandardLoad rule"
 
     assert any(
         rule.get("source_type") == "ReEDSSteamMethaneReformingDemand"
-        and rule.get("target_type") == "InterruptiblePowerLoad"
+        and rule.get("target_type") == "StandardLoad"
         for rule in rules_data
-    ), "Missing ReEDSSteamMethaneReformingDemand -> InterruptiblePowerLoad rule"
+    ), "Missing ReEDSSteamMethaneReformingDemand -> StandardLoad rule"
+
+    assert any(
+        rule.get("source_type") == "ReEDSConsumingTechnology" and rule.get("target_type") == "StandardLoad"
+        for rule in rules_data
+    ), "Missing ReEDSConsumingTechnology -> StandardLoad rule"
 
 
 def test_hydro_rule_uses_hydro_prime_mover() -> None:

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -661,10 +661,10 @@ def test_reeds_spinning_reserve_does_not_produce_non_spinning(tmp_path) -> None:
     assert len(non_spin) == 0
 
 
-def test_reeds_electrolyzer_demand_translates_to_interruptible_load(tmp_path) -> None:
-    """ReEDSElectrolyzerDemand must translate to InterruptiblePowerLoad."""
+def test_reeds_electrolyzer_demand_translates_to_standard_load(tmp_path) -> None:
+    """ReEDSElectrolyzerDemand must translate to StandardLoad."""
     from r2x_reeds.models import ReEDSElectrolyzerDemand, ReEDSRegion
-    from r2x_sienna.models import InterruptiblePowerLoad
+    from r2x_sienna.models import StandardLoad
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -685,20 +685,21 @@ def test_reeds_electrolyzer_demand_translates_to_interruptible_load(tmp_path) ->
 
     apply_rules_to_context(context)
 
-    loads = list(context.target_system.get_components(InterruptiblePowerLoad))
+    loads = list(context.target_system.get_components(StandardLoad))
     assert len(loads) == 1
 
     load = loads[0]
     assert load.name == "ELEC1"
     assert load.category == "electrolyzer"
-    assert load.max_active_power.magnitude == pytest.approx(0.8)
-    assert load.base_power.magnitude == pytest.approx(50.0)
+    assert load.constant_active_power == pytest.approx(0.8)
+    assert load.max_constant_active_power == pytest.approx(0.8)
+    assert load.base_power == pytest.approx(50.0)
 
 
-def test_reeds_datacenter_demand_translates_to_interruptible_load(tmp_path) -> None:
-    """ReEDSDataCenterDemand must translate to InterruptiblePowerLoad."""
+def test_reeds_datacenter_demand_translates_to_standard_load(tmp_path) -> None:
+    """ReEDSDataCenterDemand must translate to StandardLoad."""
     from r2x_reeds.models import ReEDSDataCenterDemand, ReEDSRegion
-    from r2x_sienna.models import InterruptiblePowerLoad
+    from r2x_sienna.models import StandardLoad
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -718,21 +719,22 @@ def test_reeds_datacenter_demand_translates_to_interruptible_load(tmp_path) -> N
 
     apply_rules_to_context(context)
 
-    loads = list(context.target_system.get_components(InterruptiblePowerLoad))
+    loads = list(context.target_system.get_components(StandardLoad))
     assert len(loads) == 1
 
     load = loads[0]
     assert load.name == "DC1"
     assert load.category == "data-center"
     # No explicit max_active_power — falls back to capacity
-    assert load.max_active_power.magnitude == pytest.approx(1.0)
-    assert load.base_power.magnitude == pytest.approx(200.0)
+    assert load.constant_active_power == pytest.approx(1.0)
+    assert load.max_constant_active_power == pytest.approx(1.0)
+    assert load.base_power == pytest.approx(200.0)
 
 
-def test_reeds_smr_demand_translates_to_interruptible_load(tmp_path) -> None:
-    """SMR electricity demand must translate to InterruptiblePowerLoad."""
+def test_reeds_smr_demand_translates_to_standard_load(tmp_path) -> None:
+    """SMR electricity demand must translate to StandardLoad."""
     from r2x_reeds.models import ReEDSRegion, ReEDSSteamMethaneReformingDemand
-    from r2x_sienna.models import InterruptiblePowerLoad
+    from r2x_sienna.models import StandardLoad
 
     context, rules = make_context_and_rules(tmp_path)
     context.source_system = System(name="source", auto_add_composed_components=True)
@@ -762,11 +764,13 @@ def test_reeds_smr_demand_translates_to_interruptible_load(tmp_path) -> None:
 
     apply_rules_to_context(context)
 
-    loads = {load.name: load for load in context.target_system.get_components(InterruptiblePowerLoad)}
+    loads = {load.name: load for load in context.target_system.get_components(StandardLoad)}
     assert set(loads) == {"SMR1", "SMR_CCS1"}
     assert loads["SMR1"].category == "smr"
-    assert loads["SMR1"].max_active_power.magnitude == pytest.approx(0.8)
-    assert loads["SMR1"].base_power.magnitude == pytest.approx(50.0)
+    assert loads["SMR1"].constant_active_power == pytest.approx(0.8)
+    assert loads["SMR1"].max_constant_active_power == pytest.approx(0.8)
+    assert loads["SMR1"].base_power == pytest.approx(50.0)
     assert loads["SMR_CCS1"].category == "smr_ccs"
-    assert loads["SMR_CCS1"].max_active_power.magnitude == pytest.approx(1.0)
-    assert loads["SMR_CCS1"].base_power.magnitude == pytest.approx(30.0)
+    assert loads["SMR_CCS1"].constant_active_power == pytest.approx(1.0)
+    assert loads["SMR_CCS1"].max_constant_active_power == pytest.approx(1.0)
+    assert loads["SMR_CCS1"].base_power == pytest.approx(30.0)


### PR DESCRIPTION
ReEDS represents electrolyzers, data centers and steam methane reforming technologies as electricity-consuming demand. These components were previously mapped to `InterruptiblePowerLoad` in Sienna which implies controllable curtailment even though the ReEDS inputs do not provide the interruption costs or curtailment constraints needed for that behavior. This PR maps the specialized and generic ReEDS consuming technologies to `StandardLoad`.