### PR TITLE
fix: Preserve ReEDS directional limits in Sienna AreaInterchange

### DIFF
--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -781,8 +781,31 @@ def get_reserve_direction(component: ReEDSReserve, context: PluginContext) -> Re
 def get_interface_flow_limits(
     component: ReEDSInterface, context: PluginContext
 ) -> Result[FromTo_ToFrom, ValueError]:
-    """Provide zeroed flow limits placeholder."""
-    return Ok(FromTo_ToFrom(from_to=0.0, to_from=0.0))
+    """Return directional flow limits from the interface's member lines."""
+    from r2x_reeds.models import ReEDSTransmissionLine
+
+    if context.source_system is None:
+        return Ok(FromTo_ToFrom(from_to=0.0, to_from=0.0))
+
+    interface_name = getattr(component, "name", "")
+    forward_limit = 0.0
+    reverse_limit = 0.0
+    for line in context.source_system.get_components(ReEDSTransmissionLine):
+        line_interface = getattr(line, "interface", None)
+        if getattr(line_interface, "name", "") != interface_name:
+            continue
+
+        limits = getattr(line, "max_active_power", None)
+        if limits is not None:
+            forward_limit += float(limits.to_from)
+            reverse_limit += float(limits.from_to)
+
+    return Ok(
+        FromTo_ToFrom(
+            from_to=_to_system_base(forward_limit, context),
+            to_from=_to_system_base(reverse_limit, context),
+        )
+    )
 
 
 @getter

--- a/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
+++ b/packages/r2x-reeds-to-sienna/src/r2x_reeds_to_sienna/getters.py
@@ -781,7 +781,11 @@ def get_reserve_direction(component: ReEDSReserve, context: PluginContext) -> Re
 def get_interface_flow_limits(
     component: ReEDSInterface, context: PluginContext
 ) -> Result[FromTo_ToFrom, ValueError]:
-    """Return directional flow limits from the interface's member lines."""
+    """Return directional flow limits from the interface's member lines.
+
+    PowerSimulations uses ``to_from`` as the positive from-area to to-area
+    limit and ``from_to`` as the magnitude of the negative reverse limit.
+    """
     from r2x_reeds.models import ReEDSTransmissionLine
 
     if context.source_system is None:
@@ -802,8 +806,8 @@ def get_interface_flow_limits(
 
     return Ok(
         FromTo_ToFrom(
-            from_to=_to_system_base(forward_limit, context),
-            to_from=_to_system_base(reverse_limit, context),
+            from_to=_to_system_base(reverse_limit, context),
+            to_from=_to_system_base(forward_limit, context),
         )
     )
 

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -248,8 +248,8 @@ def test_basic_getters_return_values(tmp_path) -> None:
     assert getters.get_area_from(interface, context).unwrap() == area
     assert getters.get_area_to(interface, context).unwrap() == area2
     flow_limits = getters.get_interface_flow_limits(interface, context).unwrap()
-    assert flow_limits.from_to == 2.0
-    assert flow_limits.to_from == 1.8
+    assert flow_limits.from_to == 1.8
+    assert flow_limits.to_from == 2.0
     assert getters.get_zero_flow(interface, context).unwrap() == 0.0
 
     # Test reserve getters

--- a/packages/r2x-reeds-to-sienna/tests/test_getters.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_getters.py
@@ -139,6 +139,16 @@ def test_basic_getters_return_values(tmp_path) -> None:
     )
     context.source_system.add_component(hvdc_line)
 
+    other_interface = ReEDSInterface(name="OTHER_IFACE", from_region=region, to_region=region2)
+    context.source_system.add_component(other_interface)
+    context.source_system.add_component(
+        ReEDSTransmissionLine(
+            name="other_interface_line",
+            interface=other_interface,
+            max_active_power={"from_to": 500.0, "to_from": 500.0},
+        )
+    )
+
     # Test thermal generator getters
     assert getters.unique_component_name(thermal, context).unwrap() == "p1_THERM"
     assert getters.get_capacity_as_rating(thermal, context).unwrap() == 1.0
@@ -238,7 +248,8 @@ def test_basic_getters_return_values(tmp_path) -> None:
     assert getters.get_area_from(interface, context).unwrap() == area
     assert getters.get_area_to(interface, context).unwrap() == area2
     flow_limits = getters.get_interface_flow_limits(interface, context).unwrap()
-    assert flow_limits.from_to == 0.0
+    assert flow_limits.from_to == 2.0
+    assert flow_limits.to_from == 1.8
     assert getters.get_zero_flow(interface, context).unwrap() == 0.0
 
     # Test reserve getters

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -416,8 +416,8 @@ def test_reeds_interface_translates_to_area_interchange(tmp_path) -> None:
     assert interchange.name == "IFACE_1_2"
     assert interchange.from_area.name == "p1"
     assert interchange.to_area.name == "p2"
-    assert interchange.flow_limits.from_to == 1.5
-    assert interchange.flow_limits.to_from == 1.75
+    assert interchange.flow_limits.from_to == 1.75
+    assert interchange.flow_limits.to_from == 1.5
     assert interchange.active_power_flow == 0.0
 
 

--- a/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
+++ b/packages/r2x-reeds-to-sienna/tests/test_translation_rule_application.py
@@ -376,7 +376,7 @@ def test_reeds_demand_translates_to_power_load(tmp_path) -> None:
 
 
 def test_reeds_interface_translates_to_area_interchange(tmp_path) -> None:
-    from r2x_reeds.models import ReEDSInterface, ReEDSRegion
+    from r2x_reeds.models import FromTo_ToFrom, ReEDSInterface, ReEDSRegion, ReEDSTransmissionLine
     from r2x_sienna.models import AreaInterchange
 
     context, rules = make_context_and_rules(tmp_path)
@@ -385,8 +385,23 @@ def test_reeds_interface_translates_to_area_interchange(tmp_path) -> None:
     region2 = ReEDSRegion(name="p2", category="region")
     context.source_system.add_component(region1)
     context.source_system.add_component(region2)
+    interface = ReEDSInterface(name="IFACE_1_2", from_region=region1, to_region=region2)
+    context.source_system.add_component(interface)
     context.source_system.add_component(
-        ReEDSInterface(name="IFACE_1_2", from_region=region1, to_region=region2)
+        ReEDSTransmissionLine(
+            name="LINE_1_2_AC",
+            interface=interface,
+            line_type="AC",
+            max_active_power=FromTo_ToFrom(from_to=150.0, to_from=100.0),
+        )
+    )
+    context.source_system.add_component(
+        ReEDSTransmissionLine(
+            name="LINE_1_2_VSC",
+            interface=interface,
+            line_type="VSC",
+            max_active_power=FromTo_ToFrom(from_to=25.0, to_from=50.0),
+        )
     )
     context.target_system = System(name="target", system_base=100.0, auto_add_composed_components=True)
     context.rules = rules
@@ -401,6 +416,8 @@ def test_reeds_interface_translates_to_area_interchange(tmp_path) -> None:
     assert interchange.name == "IFACE_1_2"
     assert interchange.from_area.name == "p1"
     assert interchange.to_area.name == "p2"
+    assert interchange.flow_limits.from_to == 1.5
+    assert interchange.flow_limits.to_from == 1.75
     assert interchange.active_power_flow == 0.0
 
 


### PR DESCRIPTION
ReEDS transmission interfaces have different forward and reverse transfer capacities. Previously these interfaces were translated to Sienna `AreaInterchange` components with zero flow limits.

This PR calculates the `AreaInterchange` limits from `ReEDSTransmissionLine` components. It sums the forward and reverse capacities independently and preserves the ReEDS direction convention when converting the values to the PowerSystems system base.