### PR TITLE
docs: refresh translation guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# R2X documentation
+
+The R2X documentation helps users choose and run a model translation and helps
+contributors extend the translation packages. Start with the page that matches
+your goal:
+
+## User guides
+
+- [Getting started](source/getting_started.md): install a translation plugin,
+  check the available packages, and choose a workflow.
+- [Translation workflows](source/dev_workflow.md): run an end-to-end Python
+  translation with the required parser, translator, and exporter packages.
+
+## Explanations
+
+- [Architecture](source/architecture.md): understand the boundaries between
+  the `r2x-cli`, parser, translation, and exporter packages.
+
+## Contributor guidance
+
+- [Development](source/development.md): set up the repository, run checks, and
+  add or maintain a translation package.
+- [Changelog](source/CHANGELOG.md): review released changes.
+
+The published site is built from the Markdown files under `docs/source/`. Keep
+examples and package names aligned with the package source and its public
+configuration classes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,23 @@
 # R2X documentation
 
-The R2X documentation helps users choose and run a model translation and helps
-contributors extend the translation packages. Start with the page that matches
-your goal:
+This directory contains the Sphinx documentation for R2X, the interoperability
+layer for moving systems between ReEDS, PLEXOS, and Sienna formats.
 
-## User guides
+## Documentation map
 
-- [Getting started](source/getting_started.md): install a translation plugin,
-  check the available packages, and choose a workflow.
-- [Translation workflows](source/dev_workflow.md): run an end-to-end Python
-  translation with the required parser, translator, and exporter packages.
+- [Getting started](source/getting_started.md): install a plugin and choose a
+  source-to-target interoperability workflow.
+- [Translation workflows](source/dev_workflow.md): contributor-oriented,
+  end-to-end parser, interoperability, and exporter examples.
+- [Architecture](source/architecture.md): parser, core, interoperability, and
+  exporter boundaries.
+- [Development](source/development.md): repository checks, plugin changes,
+  documentation conventions, and optional localized documentation maintenance.
+- [Changelog](source/CHANGELOG.md): released changes.
 
-## Explanations
+Build the current site with the same commands used by CI:
 
-- [Architecture](source/architecture.md): understand the boundaries between
-  the `r2x-cli`, parser, translation, and exporter packages.
-
-## Contributor guidance
-
-- [Development](source/development.md): set up the repository, run checks, and
-  add or maintain a translation package.
-- [Changelog](source/CHANGELOG.md): review released changes.
-
-The published site is built from the Markdown files under `docs/source/`. Keep
-examples and package names aligned with the package source and its public
-configuration classes.
+```bash
+uv sync --group docs
+uv run sphinx-build docs/source/ docs/build/
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ layer for moving systems between ReEDS, PLEXOS, and Sienna formats.
 - [Translation workflows](source/dev_workflow.md): contributor-oriented,
   end-to-end parser, interoperability, and exporter examples.
 - [Architecture](source/architecture.md): parser, core, interoperability, and
-  exporter boundaries.
+  exporter boundaries, including configuration assets such as
+  `translation_rules.json`.
 - [Development](source/development.md): repository checks and changes to
   interoperability packages.
 - [Changelog](source/CHANGELOG.md): released changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,8 @@ layer for moving systems between ReEDS, PLEXOS, and Sienna formats.
   end-to-end parser, interoperability, and exporter examples.
 - [Architecture](source/architecture.md): parser, core, interoperability, and
   exporter boundaries.
-- [Development](source/development.md): repository checks, plugin changes,
-  documentation conventions, and optional localized documentation maintenance.
+- [Development](source/development.md): repository checks and changes to
+  interoperability packages.
 - [Changelog](source/CHANGELOG.md): released changes.
 
 Build the current site with the same commands used by CI:

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -29,7 +29,10 @@ Each package under `packages/` has a related shape, with package-specific differ
 - `translation.py` exposes the public interoperability function.
 - `plugin_config.py` defines the typed configuration accepted by that function.
 - `config/` contains package configuration artifacts. Depending on the package,
-  this includes `defaults.json`, `rules.json`, and configuration package helpers.
+  this includes `defaults.json`, `translation_rules.json`, `parser_rules.json`,
+  `exporter_rules.json`, `file_mapping.json`, or package-specific `rules.json`
+  and configuration helpers. `r2x_core.PluginConfig` exposes paths to these
+  assets, including `translation_rules_path`.
 - Getter and post-processing modules contain derived-field and integration logic.
   Their names are package-specific, such as `getters.py`, `getter_utils.py`,
   `getters_utils.py`, or `getters_mappings.py`.
@@ -48,13 +51,17 @@ pattern while their configuration artifacts and post-processing modules differ.
 ## Rules and getters
 
 Rules handle direct field mappings, defaults, source and target component types,
-and filters. Getter functions handle values that require computation or context,
-such as unit conversion, commitment status, outage rates, memberships, and
-name resolution. Supplemental attributes and post-processing helpers handle
-relationships and data that cannot be represented by a simple field mapping.
-Keep these responsibilities separate: put a stable mapping in `rules.json`,
-put computed values in a getter, and use the package's post-processing helpers
-for integration-specific work.
+and filters. Interoperability packages commonly load their declarative mapping
+records from `config/translation_rules.json` through
+`config.translation_rules_path`; packages with separate parser or exporter
+contracts may use the corresponding `parser_rules.json`, `exporter_rules.json`,
+or package-specific `rules.json`. Getter functions handle values that require
+computation or context, such as unit conversion, commitment status, outage rates,
+memberships, and name resolution. Supplemental attributes and post-processing
+helpers handle relationships and data that cannot be represented by a simple
+field mapping. Keep these responsibilities separate: put stable mapping records
+in the appropriate JSON asset, put computed values in a getter, and use the
+package's post-processing helpers for integration-specific work.
 
 When a mapping changes, update the rule and the behavior-focused tests together.
 When a getter changes, test both its returned value and the resulting target

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -22,7 +22,7 @@ flowchart LR
 | Interoperability | Maps source components and fields to target components and attaches derived data. | This repository |
 | Exporter | Writes a target system to its native format. | [`r2x-plexos`](https://github.com/NatLabRockies/r2x-plexos), [`r2x-sienna`](https://github.com/NatLabRockies/r2x-sienna) |
 
-## Translation package structure
+## Interoperability package structure
 
 Each package under `packages/` has a related shape, with package-specific differences:
 

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -1,0 +1,54 @@
+# Architecture
+
+R2X is the translation layer in the broader r2x model-interoperability
+workflow. Each stage has a focused responsibility:
+
+```text
+source model
+    │
+    ▼
+parser package  ──>  r2x_core.System  ──>  R2X translation plugin
+                                                    │
+                                                    ▼
+                                            target r2x_core.System
+                                                    │
+                                                    ▼
+                                             exporter package
+```
+
+## Package boundaries
+
+| Layer | Responsibility | Examples |
+| --- | --- | --- |
+| CLI | Discovers plugins, manages the Python environment, and runs pipelines. | `r2x-cli` |
+| Parser | Reads a source format into an `r2x_core.System`. | `r2x-reeds`, `r2x-plexos`, `r2x-sienna` |
+| Core | Provides the shared `System`, `PluginContext`, `Rule`, and rule-engine APIs. | `r2x-core` |
+| Translation | Maps source components and fields to target components and attaches derived data. | This repository |
+| Exporter | Writes a target system to its native format. | `r2x-plexos`, `r2x-sienna` |
+
+## Translation package structure
+
+Each package under `packages/` has the same broad shape:
+
+- `translation.py` exposes the public translation function.
+- `plugin_config.py` defines the typed configuration accepted by that function.
+- `config/rules.json` contains declarative source-to-target mappings.
+- `getters.py` and `getters_utils.py` contain derived-field and post-processing logic.
+- `tests/` exercises translation behavior and important edge cases.
+
+For example, `r2x-reeds-to-plexos` exposes
+`reeds_to_plexos(system, config)`. It loads its rules, creates the target PLEXOS
+system, applies the mappings, and then attaches reserve, generator, region-load,
+and purchaser time series.
+
+## Rules and getters
+
+Rules handle direct field mappings, defaults, source and target component types,
+and filters. Getter functions handle values that require computation or context,
+such as unit conversion, commitment status, outage rates, memberships, and
+name resolution. Keep these responsibilities separate: put a stable mapping in
+`rules.json`, and put computation that needs code or context in a getter.
+
+When a mapping changes, update the rule and the behavior-focused tests together.
+When a getter changes, test both its returned value and the resulting target
+component or time series where feasible.

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -16,34 +16,45 @@ flowchart LR
 
 | Layer | Responsibility | Examples |
 | --- | --- | --- |
-| CLI | Discovers plugins, manages the Python environment, and runs pipelines. | `r2x-cli` |
-| Parser | Reads a source format into an `r2x_core.System`. | `r2x-reeds`, `r2x-plexos`, `r2x-sienna` |
-| Core | Provides the shared `System`, `PluginContext`, `Rule`, and rule-engine APIs. | `r2x-core` |
-| Translation | Maps source components and fields to target components and attaches derived data. | This repository |
-| Exporter | Writes a target system to its native format. | `r2x-plexos`, `r2x-sienna` |
+| CLI | Discovers plugins, manages the Python environment, and runs pipelines. | [`r2x-cli`](https://github.com/NatLabRockies/r2x-cli) |
+| Parser | Reads a source format into an `r2x_core.System`. | [`r2x-reeds`](https://github.com/NatLabRockies/r2x-reeds), [`r2x-plexos`](https://github.com/NatLabRockies/r2x-plexos), [`r2x-sienna`](https://github.com/NatLabRockies/r2x-sienna) |
+| Core | Provides the shared `System`, `PluginContext`, `Rule`, and rule-engine APIs. | [`r2x-core`](https://github.com/NatLabRockies/r2x-core) |
+| Interoperability | Maps source components and fields to target components and attaches derived data. | This repository |
+| Exporter | Writes a target system to its native format. | [`r2x-plexos`](https://github.com/NatLabRockies/r2x-plexos), [`r2x-sienna`](https://github.com/NatLabRockies/r2x-sienna) |
 
 ## Translation package structure
 
-Each package under `packages/` has the same broad shape:
+Each package under `packages/` has a related shape, with package-specific differences:
 
-- `translation.py` exposes the public translation function.
+- `translation.py` exposes the public interoperability function.
 - `plugin_config.py` defines the typed configuration accepted by that function.
-- `config/rules.json` contains declarative source-to-target mappings.
-- Getter and post-processing modules contain derived-field and integration logic. Their names are package-specific, such as `getters.py`, `getter_utils.py`, or `getters_mappings.py`.
+- `config/` contains package configuration artifacts. Depending on the package,
+  this includes `defaults.json`, `rules.json`, and configuration package helpers.
+- Getter and post-processing modules contain derived-field and integration logic.
+  Their names are package-specific, such as `getters.py`, `getter_utils.py`,
+  `getters_utils.py`, or `getters_mappings.py`.
 - `tests/` exercises translation behavior and important edge cases.
+
+For the shared configuration and plugin conventions, see the
+[`r2x-core` plugin-system documentation](https://natlabrockies.github.io/r2x-core/explanations/plugin-system/)
+and [`r2x-core` rules documentation](https://natlabrockies.github.io/r2x-core/explanations/rules-system/).
 
 For example, `r2x-reeds-to-plexos` exposes
 `reeds_to_plexos(system, config)`. It loads its rules, creates the target PLEXOS
 system, applies the mappings, and then attaches reserve, generator, region-load,
-and purchaser time series.
+and purchaser time series. The other packages follow the same public-function
+pattern while their configuration artifacts and post-processing modules differ.
 
 ## Rules and getters
 
 Rules handle direct field mappings, defaults, source and target component types,
 and filters. Getter functions handle values that require computation or context,
 such as unit conversion, commitment status, outage rates, memberships, and
-name resolution. Keep these responsibilities separate: put a stable mapping in
-`rules.json`, and put computation that needs code or context in a getter.
+name resolution. Supplemental attributes and post-processing helpers handle
+relationships and data that cannot be represented by a simple field mapping.
+Keep these responsibilities separate: put a stable mapping in `rules.json`,
+put computed values in a getter, and use the package's post-processing helpers
+for integration-specific work.
 
 When a mapping changes, update the rule and the behavior-focused tests together.
 When a getter changes, test both its returned value and the resulting target

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -3,17 +3,13 @@
 R2X is the translation layer in the broader r2x model-interoperability
 workflow. Each stage has a focused responsibility:
 
-```text
-source model
-    │
-    ▼
-parser package  ──>  r2x_core.System  ──>  R2X translation plugin
-                                                    │
-                                                    ▼
-                                            target r2x_core.System
-                                                    │
-                                                    ▼
-                                             exporter package
+```mermaid
+flowchart LR
+    source[Source model] --> parser[Parser package]
+    parser --> system[r2x_core.System]
+    system --> translation[R2X translation plugin]
+    translation --> target[Target r2x_core.System]
+    target --> exporter[Exporter package]
 ```
 
 ## Package boundaries
@@ -33,7 +29,7 @@ Each package under `packages/` has the same broad shape:
 - `translation.py` exposes the public translation function.
 - `plugin_config.py` defines the typed configuration accepted by that function.
 - `config/rules.json` contains declarative source-to-target mappings.
-- `getters.py` and `getters_utils.py` contain derived-field and post-processing logic.
+- Getter and post-processing modules contain derived-field and integration logic. Their names are package-specific, such as `getters.py`, `getter_utils.py`, or `getters_mappings.py`.
 - `tests/` exercises translation behavior and important edge cases.
 
 For example, `r2x-reeds-to-plexos` exposes

--- a/docs/source/dev_workflow.md
+++ b/docs/source/dev_workflow.md
@@ -1,8 +1,14 @@
 # Translation workflows
 
-Each workflow below shows how to install the upstream parser and exporter as
-editable packages and provides a complete Python API example. Use the guide
-that matches your source and target formats.
+These pages document the supported translation workflows in this repository.
+They are end-to-end contributor examples: each one shows parser setup, the
+R2X interoperability function, and target export. They intentionally expose the
+integration boundary so a contributor can adapt the workflow to a real input
+system.
+
+For the smaller public API surface, start with [Getting started](getting_started.md).
+For the package boundaries and rule-engine responsibilities, see
+[Architecture](architecture.md).
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/source/dev_workflow.md
+++ b/docs/source/dev_workflow.md
@@ -1,7 +1,8 @@
-# Dev Workflow
+# Translation workflows
 
-Each workflow below shows how to install the relevant upstream packages as editable installs
-(so local changes are picked up immediately) and provides a full end-to-end example script.
+Each workflow below shows how to install the upstream parser and exporter as
+editable packages and provides a complete Python API example. Use the guide
+that matches your source and target formats.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -1,124 +1,85 @@
 # Development
 
-This page covers the repository workflow for updating translation packages and
-keeping the documentation accurate.
+This page documents only the checks and conventions needed to contribute to
+this repository's interoperability plugins. It is not a general project or
+translation-management guide.
 
-## Set up the repository
+## Run the repository checks
 
 The project uses a uv workspace. From the repository root:
 
 ```bash
 uv sync
-```
-
-The supported Python range is Python 3.11 through 3.13. The workspace includes
-the translation packages under `packages/*` and their tests.
-
-## Run checks
-
-Run the Python test suite:
-
-```bash
 uv run pytest --cov --cov-report=xml
-```
-
-Run the configured code-quality hooks:
-
-```bash
 uv run prek run --show-diff-on-failure --color=always --all-files --hook-stage pre-push
 ```
 
-The CI workflow also runs package smoke tests by building wheels and installing
-each workspace package outside the uv workspace. Preserve those checks when
-changing package metadata or entry points.
+The CI workflow also builds wheels and installs each workspace package outside
+the uv workspace. Preserve package metadata, entry points, and this smoke-test
+coverage when changing a package.
 
-## Add or update a translation
+The documentation workflow uses the existing Sphinx setup and Python docs
+extras:
 
-1. Choose the package under `packages/` that owns the source-to-target direction.
+```bash
+uv sync --group docs
+uv run sphinx-build docs/source/ docs/build/
+```
+
+## Change a translation plugin
+
+1. Choose the package under `packages/` for the source-to-target direction.
 2. Confirm the source and target component APIs in the parser, exporter, and
-   `r2x-core` packages before changing a mapping.
-3. Update `config/rules.json` for direct mappings, defaults, filters, and type
-   changes.
-4. Update `getters.py` or `getters_utils.py` only when the value needs
-   computation, context, unit conversion, membership resolution, or
-   post-processing.
-5. Add or update a behavior-focused test under the package's `tests/` directory.
-6. Update the package README and the matching workflow page when the public
-   configuration, supported behavior, or setup changes.
-7. Run the focused package tests, then the complete checks above.
+   `r2x-core` packages.
+3. Update `config/rules.json` for declarative mappings, defaults, filters, and
+   type changes.
+4. Update the package-specific getter or post-processing module when a value
+   requires computation, context, unit conversion, membership resolution, or
+   time-series handling.
+5. Add or update a behavior-focused test under that package's `tests/` directory.
+6. Update the matching workflow page when the public configuration, setup, or
+   supported behavior changes.
+7. Run the focused tests, the repository checks, and the documentation build.
 
-Avoid copying a private or application-specific workflow into the generic docs.
-Document only public package APIs and verify examples against the current source.
+A new translation direction must expose a public translation function and typed
+configuration, register its entry point, include its rules and integration
+logic, and include a test that verifies a representative source-to-target
+result. Add the direction to `docs/source/dev_workflow.md` and keep its page
+focused on the actual public integration boundary.
 
-## Add a new translation direction
+## Documentation changes
 
-A new direction should expose one clearly named public function through the
-package entry-point metadata. Define a typed configuration class, add the rules
-and getters, and include at least one end-to-end test that builds a minimal
-source system and verifies the target system. Add a workflow page with:
+Use the Diataxis categories already represented by this documentation:
 
-- required parser, translation, and exporter packages;
-- setup commands that match the supported package APIs;
-- a complete example with realistic placeholders;
-- validation or expected-output guidance; and
-- known limitations, if the implementation has any.
+tutorials teach a first successful workflow; how-to guides solve a specific
+working task; reference pages describe public contracts; and explanations
+describe architecture and design decisions.
 
-Add the page to `docs/source/dev_workflow.md` and the documentation site
-navigation when the Astro site is present.
+Keep commands and API examples grounded in the repository and its public
+packages. Do not copy private application workflows into the generic R2X docs.
+When a command or API changes, update the relevant example and verify it with the
+same environment used by CI.
 
-## Documentation structure
+## Translated documentation
 
-The Markdown source uses the Diataxis categories:
+R2X is an interoperability layer, not an English-translation product. This
+section applies only if the documentation itself is intentionally localized.
+It does not describe R2X translation plugins or model interoperability.
 
-- tutorials teach a first successful workflow;
-- how-to guides solve a specific task;
-- reference pages describe public contracts and options; and
-- explanations describe architecture and design decisions.
-
-Keep one page focused on one reader goal. Put prerequisites before actions and
-place verification immediately after the action it checks.
-
-## Add and maintain translations
-
-Documentation translations are maintained as parallel pages, not as machine
-translated output committed without review. When adding a language:
+Documentation translations are maintained as parallel pages and require review:
 
 1. Copy the current English page into the language-specific documentation
    location defined by the site configuration.
-2. Preserve the page's frontmatter, headings, code fences, links, tables, and
-   command or API names. Translate prose, navigation labels, and accessible
-   text, but do not translate package names, Python identifiers, CLI commands,
-   file paths, or configuration keys.
-3. Add the translated page to the same sidebar position as the English page and
-   add the language to the site language selector when the site supports one.
-4. Record the English source page and its source revision in the translated
-   page's frontmatter or maintenance metadata. This makes stale translations
-   discoverable after an English update.
-5. Have a reviewer who understands the target language and the R2X workflow
+2. Preserve frontmatter, headings, code fences, links, tables, package names,
+   Python identifiers, CLI commands, file paths, and configuration keys. Translate
+   prose, navigation labels, and accessible text only.
+3. Put the localized page in the same navigation position as the English page.
+4. Record the English source page and source revision in the localized page's
+   maintenance metadata so stale content can be found.
+5. Have a reviewer who understands both the target language and the R2X workflow
    verify technical meaning, commands, links, and terminology.
-6. Build the documentation and inspect the rendered translated page before
-   merging.
+6. Build the docs and inspect the rendered localized page before merging.
 
-When changing an English page, check its sibling translations in the same
-change. Update translated prose when the change affects behavior, commands,
-headings, links, or navigation. If a translation cannot be updated in the same
-change, mark it as out of date and link to the current English page rather than
-silently presenting stale instructions as current.
-
-Keep terminology consistent with the source page. In particular, preserve the
-names of R2X packages, `r2x_core` types, model formats, and configuration fields
-exactly so readers can search for them and copy examples.
-
-## Documentation build
-
-The Astro site is in `docs/` and uses npm with the committed lockfile. From
-that directory:
-
-```bash
-npm ci
-npm run build
-```
-
-The GitHub Actions documentation workflow runs the same build on pull requests
-and publishes the generated site from `main`. Do not replace the Python CI
-requirements with the documentation build or remove the existing Python checks.
+When an English page changes, check its localized siblings. If a localized page
+cannot be updated in the same change, mark it out of date and link to the
+current English page rather than presenting stale instructions as current.

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -1,0 +1,124 @@
+# Development
+
+This page covers the repository workflow for updating translation packages and
+keeping the documentation accurate.
+
+## Set up the repository
+
+The project uses a uv workspace. From the repository root:
+
+```bash
+uv sync
+```
+
+The supported Python range is Python 3.11 through 3.13. The workspace includes
+the translation packages under `packages/*` and their tests.
+
+## Run checks
+
+Run the Python test suite:
+
+```bash
+uv run pytest --cov --cov-report=xml
+```
+
+Run the configured code-quality hooks:
+
+```bash
+uv run prek run --show-diff-on-failure --color=always --all-files --hook-stage pre-push
+```
+
+The CI workflow also runs package smoke tests by building wheels and installing
+each workspace package outside the uv workspace. Preserve those checks when
+changing package metadata or entry points.
+
+## Add or update a translation
+
+1. Choose the package under `packages/` that owns the source-to-target direction.
+2. Confirm the source and target component APIs in the parser, exporter, and
+   `r2x-core` packages before changing a mapping.
+3. Update `config/rules.json` for direct mappings, defaults, filters, and type
+   changes.
+4. Update `getters.py` or `getters_utils.py` only when the value needs
+   computation, context, unit conversion, membership resolution, or
+   post-processing.
+5. Add or update a behavior-focused test under the package's `tests/` directory.
+6. Update the package README and the matching workflow page when the public
+   configuration, supported behavior, or setup changes.
+7. Run the focused package tests, then the complete checks above.
+
+Avoid copying a private or application-specific workflow into the generic docs.
+Document only public package APIs and verify examples against the current source.
+
+## Add a new translation direction
+
+A new direction should expose one clearly named public function through the
+package entry-point metadata. Define a typed configuration class, add the rules
+and getters, and include at least one end-to-end test that builds a minimal
+source system and verifies the target system. Add a workflow page with:
+
+- required parser, translation, and exporter packages;
+- setup commands that match the supported package APIs;
+- a complete example with realistic placeholders;
+- validation or expected-output guidance; and
+- known limitations, if the implementation has any.
+
+Add the page to `docs/source/dev_workflow.md` and the documentation site
+navigation when the Astro site is present.
+
+## Documentation structure
+
+The Markdown source uses the Diataxis categories:
+
+- tutorials teach a first successful workflow;
+- how-to guides solve a specific task;
+- reference pages describe public contracts and options; and
+- explanations describe architecture and design decisions.
+
+Keep one page focused on one reader goal. Put prerequisites before actions and
+place verification immediately after the action it checks.
+
+## Add and maintain translations
+
+Documentation translations are maintained as parallel pages, not as machine
+translated output committed without review. When adding a language:
+
+1. Copy the current English page into the language-specific documentation
+   location defined by the site configuration.
+2. Preserve the page's frontmatter, headings, code fences, links, tables, and
+   command or API names. Translate prose, navigation labels, and accessible
+   text, but do not translate package names, Python identifiers, CLI commands,
+   file paths, or configuration keys.
+3. Add the translated page to the same sidebar position as the English page and
+   add the language to the site language selector when the site supports one.
+4. Record the English source page and its source revision in the translated
+   page's frontmatter or maintenance metadata. This makes stale translations
+   discoverable after an English update.
+5. Have a reviewer who understands the target language and the R2X workflow
+   verify technical meaning, commands, links, and terminology.
+6. Build the documentation and inspect the rendered translated page before
+   merging.
+
+When changing an English page, check its sibling translations in the same
+change. Update translated prose when the change affects behavior, commands,
+headings, links, or navigation. If a translation cannot be updated in the same
+change, mark it as out of date and link to the current English page rather than
+silently presenting stale instructions as current.
+
+Keep terminology consistent with the source page. In particular, preserve the
+names of R2X packages, `r2x_core` types, model formats, and configuration fields
+exactly so readers can search for them and copy examples.
+
+## Documentation build
+
+The Astro site is in `docs/` and uses npm with the committed lockfile. From
+that directory:
+
+```bash
+npm ci
+npm run build
+```
+
+The GitHub Actions documentation workflow runs the same build on pull requests
+and publishes the generated site from `main`. Do not replace the Python CI
+requirements with the documentation build or remove the existing Python checks.

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -41,7 +41,7 @@ uv run sphinx-build docs/source/ docs/build/
    supported behavior changes.
 7. Run the focused tests, the repository checks, and the documentation build.
 
-A new translation direction must expose a public translation function and typed
+A new interoperability direction must expose a public function and typed
 configuration, register its entry point, include its rules and integration
 logic, and include a test that verifies a representative source-to-target
 result. Add the direction to `docs/source/dev_workflow.md` and keep its page
@@ -49,37 +49,7 @@ focused on the actual public integration boundary.
 
 ## Documentation changes
 
-Use the Diataxis categories already represented by this documentation:
-
-tutorials teach a first successful workflow; how-to guides solve a specific
-working task; reference pages describe public contracts; and explanations
-describe architecture and design decisions.
-
 Keep commands and API examples grounded in the repository and its public
 packages. Do not copy private application workflows into the generic R2X docs.
 When a command or API changes, update the relevant example and verify it with the
 same environment used by CI.
-
-## Translated documentation
-
-R2X is an interoperability layer, not an English-translation product. This
-section applies only if the documentation itself is intentionally localized.
-It does not describe R2X translation plugins or model interoperability.
-
-Documentation translations are maintained as parallel pages and require review:
-
-1. Copy the current English page into the language-specific documentation
-   location defined by the site configuration.
-2. Preserve frontmatter, headings, code fences, links, tables, package names,
-   Python identifiers, CLI commands, file paths, and configuration keys. Translate
-   prose, navigation labels, and accessible text only.
-3. Put the localized page in the same navigation position as the English page.
-4. Record the English source page and source revision in the localized page's
-   maintenance metadata so stale content can be found.
-5. Have a reviewer who understands both the target language and the R2X workflow
-   verify technical meaning, commands, links, and terminology.
-6. Build the docs and inspect the rendered localized page before merging.
-
-When an English page changes, check its localized siblings. If a localized page
-cannot be updated in the same change, mark it out of date and link to the
-current English page rather than presenting stale instructions as current.

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -32,8 +32,11 @@ uv run sphinx-build docs/source/ docs/build/
 1. Choose the package under `packages/` for the source-to-target direction.
 2. Confirm the source and target component APIs in the parser, exporter, and
    `r2x-core` packages.
-3. Update `config/rules.json` for declarative mappings, defaults, filters, and
-   type changes.
+3. Update the appropriate configuration asset under `config/`. For
+   interoperability mappings, this is commonly `translation_rules.json`; use
+   `parser_rules.json`, `exporter_rules.json`, or a package-specific `rules.json`
+   when that is the package's contract. `PluginConfig` exposes the resolved
+   path, for example `config.translation_rules_path`.
 4. Update the package-specific getter or post-processing module when a value
    requires computation, context, unit conversion, membership resolution, or
    time-series handling.
@@ -43,9 +46,9 @@ uv run sphinx-build docs/source/ docs/build/
 7. Run the focused tests, the repository checks, and the documentation build.
 
 A new interoperability direction must expose a public function and typed
-configuration, register its entry point, include its rules and integration
-logic, and include a test that verifies a representative source-to-target
-result. Add the direction to `docs/source/dev_workflow.md` and keep its page
+configuration, register its entry point, include its configuration assets such
+as `translation_rules.json` and its integration logic, and include a test that
+verifies a representative source-to-target result. Add the direction to `docs/source/dev_workflow.md` and keep its page
 focused on the actual public integration boundary. Follow the shared plugin and
 rule conventions in the [`r2x-core` plugin-system documentation](https://natlabrockies.github.io/r2x-core/explanations/plugin-system/)
 and [`r2x-core` rules documentation](https://natlabrockies.github.io/r2x-core/explanations/rules-system/).

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -6,7 +6,8 @@ translation-management guide.
 
 ## Run the repository checks
 
-The project uses a uv workspace. From the repository root:
+The project uses a uv workspace. From the repository root, install the
+runtime and development dependencies:
 
 ```bash
 uv sync
@@ -19,14 +20,14 @@ the uv workspace. Preserve package metadata, entry points, and this smoke-test
 coverage when changing a package.
 
 The documentation workflow uses the existing Sphinx setup and Python docs
-extras:
+extras. Build it before opening a documentation PR:
 
 ```bash
 uv sync --group docs
 uv run sphinx-build docs/source/ docs/build/
 ```
 
-## Change a translation plugin
+## Change an interoperability plugin
 
 1. Choose the package under `packages/` for the source-to-target direction.
 2. Confirm the source and target component APIs in the parser, exporter, and
@@ -45,7 +46,9 @@ A new interoperability direction must expose a public function and typed
 configuration, register its entry point, include its rules and integration
 logic, and include a test that verifies a representative source-to-target
 result. Add the direction to `docs/source/dev_workflow.md` and keep its page
-focused on the actual public integration boundary.
+focused on the actual public integration boundary. Follow the shared plugin and
+rule conventions in the [`r2x-core` plugin-system documentation](https://natlabrockies.github.io/r2x-core/explanations/plugin-system/)
+and [`r2x-core` rules documentation](https://natlabrockies.github.io/r2x-core/explanations/rules-system/).
 
 ## Documentation changes
 

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -7,8 +7,10 @@ published as separate Python packages and are orchestrated by the
 ## Prerequisites
 
 Use Python 3.11, 3.12, or 3.13. For a managed environment, install
-[uv](https://docs.astral.sh/uv/). The command-line workflow also requires the
-[r2x-cli](https://github.com/NatlabRockies/r2x-cli).
+[uv](https://docs.astral.sh/uv/). For the command-line workflow, install
+[r2x-cli](https://github.com/NatlabRockies/r2x-cli) using its
+[installation instructions](https://github.com/NatLabRockies/r2x-cli#installation)
+before running the `r2x` commands below.
 
 ## Install a translation plugin
 
@@ -27,8 +29,9 @@ To manage the environment yourself, install a published package with `pip`:
 python -m pip install r2x-reeds-to-plexos
 ```
 
-See the package [README files](https://github.com/NatlabRockies/R2X/tree/main/packages)
-for package-specific entry points and examples.
+See the [workflow guides](dev_workflow.md) for package-specific setup and
+examples. Package READMEs may contain older examples while their APIs are being
+aligned.
 
 ## Choose a workflow
 
@@ -71,6 +74,5 @@ uv sync
 uv run pytest
 ```
 
-The documentation build is maintained separately from the Python environment.
 See [development](development.md) for the documentation commands and the
 translation-package maintenance workflow.

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,0 +1,76 @@
+# Getting started
+
+R2X provides translation plugins for ReEDS, PLEXOS, and Sienna. The plugins are
+published as separate Python packages and are orchestrated by the
+[r2x-cli](https://github.com/NatlabRockies/r2x-cli) ecosystem.
+
+## Prerequisites
+
+Use Python 3.11, 3.12, or 3.13. For a managed environment, install
+[uv](https://docs.astral.sh/uv/). The command-line workflow also requires the
+[r2x-cli](https://github.com/NatlabRockies/r2x-cli).
+
+## Install a translation plugin
+
+The CLI installs a plugin and its required parser, exporter, and core packages:
+
+```bash
+r2x install r2x-reeds-to-plexos
+r2x install r2x-reeds-to-sienna
+r2x install r2x-plexos-to-sienna
+r2x install r2x-sienna-to-plexos
+```
+
+To manage the environment yourself, install a published package with `pip`:
+
+```bash
+python -m pip install r2x-reeds-to-plexos
+```
+
+See the package [README files](https://github.com/NatlabRockies/R2X/tree/main/packages)
+for package-specific entry points and examples.
+
+## Choose a workflow
+
+| Source | Target | Guide |
+| --- | --- | --- |
+| ReEDS | PLEXOS | [ReEDS to PLEXOS](reeds_to_plexos.md) |
+| ReEDS | Sienna | [ReEDS to Sienna](reeds_to_sienna.md) |
+| PLEXOS | Sienna | [PLEXOS to Sienna](plexos_to_sienna.md) |
+| Sienna | PLEXOS | [Sienna to PLEXOS](sienna_to_plexos.md) |
+
+Every workflow needs a parser for the source model, the matching R2X
+translation package, and an exporter for the target model. Keep the parser and
+exporter versions compatible with the translation package version.
+
+## Run the Python API
+
+The public translation functions accept an `r2x_core.System` and a typed plugin
+configuration. A minimal translation call looks like this:
+
+```python
+from r2x_core import System
+from r2x_reeds_to_plexos.plugin_config import ReedsToPlexosConfig
+from r2x_reeds_to_plexos.translation import reeds_to_plexos
+
+source_system = System(name="reeds-source", auto_add_composed_components=True)
+translated_system = reeds_to_plexos(source_system, ReedsToPlexosConfig())
+```
+
+The source system must contain the component types expected by the selected
+translation. Use the workflow guides for parser setup, input paths, time-series
+storage, and exporter configuration.
+
+## Verify a local checkout
+
+From a checkout of this repository, install the development environment and run
+the tests:
+
+```bash
+uv sync
+uv run pytest
+```
+
+The documentation build is maintained separately from the Python environment.
+See [development](development.md) for the documentation commands and the
+translation-package maintenance workflow.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,20 +2,22 @@
 
 Translation plugins for ReEDS, PLEXOS, and Sienna model interoperability.
 
-This repository contains the translation layer in the
-[r2x-cli](https://github.com/NatlabRockies/r2x-cli) ecosystem. For the shared
-plugin architecture, rule engine, `System`, `DataStore`, and units, see
-[r2x-core](https://nrel.github.io/r2x-core/).
+This repository contains the interoperability layer in the
+[r2x-cli](https://github.com/NatlabRockies/r2x-cli) ecosystem. It connects
+model-specific parsers and exporters through shared
+[`r2x-core`](https://github.com/NatLabRockies/r2x-core) systems, rules, plugins,
+data stores, and units.
 
 ## Start here
 
 - [Getting started](getting_started.md) explains installation and how to choose
   a translation workflow.
-- [Translation workflows](dev_workflow.md) contains end-to-end Python examples.
-- [Architecture](architecture.md) explains the parser, translation, and
+- [Translation workflows](dev_workflow.md) contains contributor-oriented,
+  end-to-end interoperability examples.
+- [Architecture](architecture.md) explains the parser, interoperability, and
   exporter boundaries.
-- [Development](development.md) covers checks, adding translation directions,
-  and maintaining translated documentation.
+- [Development](development.md) covers repository checks and changes to
+  interoperability packages.
 
 ## Translation plugins
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,13 +11,18 @@ data stores, and units.
 ## Start here
 
 - [Getting started](getting_started.md) explains installation and how to choose
-  a translation workflow.
+  an interoperability workflow.
 - [Translation workflows](dev_workflow.md) contains contributor-oriented,
   end-to-end interoperability examples.
 - [Architecture](architecture.md) explains the parser, interoperability, and
   exporter boundaries.
 - [Development](development.md) covers repository checks and changes to
   interoperability packages.
+
+The `r2x-cli` orchestrates installed plugins, while
+[`r2x-core`](https://github.com/NatLabRockies/r2x-core) supplies the shared
+system, plugin, data, and rule infrastructure. This repository provides the
+model-to-model interoperability functions between those layers.
 
 ## Translation plugins
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,26 +1,34 @@
-# R2X Translation Plugins
+# R2X documentation
 
-Translation plugins for power system models.
-ReEDS, PLEXOS, Sienna — any direction.
+Translation plugins for ReEDS, PLEXOS, and Sienna model interoperability.
 
-This repo houses the translation plugins for the
-[r2x-cli](https://github.com/NatlabRockies/r2x-cli) ecosystem.
-For the core framework (plugin architecture, rules engine, System,
-DataStore, units), see
+This repository contains the translation layer in the
+[r2x-cli](https://github.com/NatlabRockies/r2x-cli) ecosystem. For the shared
+plugin architecture, rule engine, `System`, `DataStore`, and units, see
 [r2x-core](https://nrel.github.io/r2x-core/).
 
-## Translation Plugins
+## Start here
+
+- [Getting started](getting_started.md) explains installation and how to choose
+  a translation workflow.
+- [Translation workflows](dev_workflow.md) contains end-to-end Python examples.
+- [Architecture](architecture.md) explains the parser, translation, and
+  exporter boundaries.
+- [Development](development.md) covers checks, adding translation directions,
+  and maintaining translated documentation.
+
+## Translation plugins
 
 | Package | Direction | Rules |
 | --- | --- | ---: |
-| [`r2x-reeds-to-plexos`](https://github.com/NatlabRockies/R2X/tree/main/packages/r2x-reeds-to-plexos) | ReEDS → PLEXOS | 34 |
-| [`r2x-reeds-to-sienna`](https://github.com/NatlabRockies/R2X/tree/main/packages/r2x-reeds-to-sienna) | ReEDS → Sienna | — |
-| [`r2x-plexos-to-sienna`](https://github.com/NatlabRockies/R2X/tree/main/packages/r2x-plexos-to-sienna) | PLEXOS → Sienna | 21 |
-| [`r2x-sienna-to-plexos`](https://github.com/NatlabRockies/R2X/tree/main/packages/r2x-sienna-to-plexos) | Sienna → PLEXOS | 44 |
+| [`r2x-reeds-to-plexos`](https://github.com/NatLabRockies/R2X/tree/main/packages/r2x-reeds-to-plexos) | ReEDS → PLEXOS | 34 |
+| [`r2x-reeds-to-sienna`](https://github.com/NatLabRockies/R2X/tree/main/packages/r2x-reeds-to-sienna) | ReEDS → Sienna | — |
+| [`r2x-plexos-to-sienna`](https://github.com/NatLabRockies/R2X/tree/main/packages/r2x-plexos-to-sienna) | PLEXOS → Sienna | 21 |
+| [`r2x-sienna-to-plexos`](https://github.com/NatLabRockies/R2X/tree/main/packages/r2x-sienna-to-plexos) | Sienna → PLEXOS | 44 |
 
-## Model Compatibility
+## Model compatibility
 
-| R2X Version | Supported Inputs | Supported Outputs |
+| R2X version | Supported inputs | Supported outputs |
 | --- | --- | --- |
 | 2.0 | ReEDS (v2024.8.0) | PLEXOS (9.0, 9.2, 10, 11) |
 |     | Sienna (PSY 4.0) | Sienna (PSY 4.0, 5.0) |
@@ -30,27 +38,26 @@ DataStore, units), see
 
 | Package | Description |
 | --- | --- |
-| [r2x-cli](https://github.com/NatlabRockies/r2x-cli) | Rust CLI that discovers, installs, and runs any r2x plugin |
-| [r2x-core](https://github.com/NatlabRockies/r2x-core) | Shared plugin framework: `PluginContext`, `Rule`, `System`, `@getter` registry |
-| [r2x-reeds](https://github.com/NatlabRockies/r2x-reeds) | ReEDS parser, transform plugins, and component models |
-| [r2x-plexos](https://github.com/NatlabRockies/r2x-plexos) | PLEXOS parser/exporter and component models |
-| [r2x-sienna](https://github.com/NREL-Sienna/r2x-sienna) | Sienna parser/exporter and PowerSystems.jl-compatible models |
-| [infrasys](https://github.com/NatlabRockies/infrasys) | Foundational System container and time series management |
-| [plexosdb](https://github.com/NatlabRockies/plexosdb) | Standalone PLEXOS XML database reader/writer |
+| [r2x-cli](https://github.com/NatLabRockies/r2x-cli) | CLI that discovers, installs, and runs r2x plugins |
+| [r2x-core](https://github.com/NatLabRockies/r2x-core) | Shared plugin framework and rule engine |
+| [r2x-reeds](https://github.com/NatLabRockies/r2x-reeds) | ReEDS parser, transform plugins, and component models |
+| [r2x-plexos](https://github.com/NatLabRockies/r2x-plexos) | PLEXOS parser/exporter and component models |
+| [r2x-sienna](https://github.com/NREL-Sienna/r2x-sienna) | Sienna parser/exporter and compatible component models |
+| [infrasys](https://github.com/NatLabRockies/infrasys) | Foundational `System` container and time-series management |
+| [plexosdb](https://github.com/NatLabRockies/plexosdb) | Standalone PLEXOS XML database reader/writer |
 
 ## Roadmap
 
-- [Active issues](https://github.com/NatlabRockies/R2X/issues?q=is%3Aopen+is%3Aissue+label%3A%22Working+on+it+%F0%9F%92%AA%22+sort%3Aupdated-asc):
-  Currently in progress.
-- [Prioritized backlog](https://github.com/NatlabRockies/R2X/issues?q=is%3Aopen+is%3Aissue+label%3ABacklog):
-  Up next.
-- [Nice-to-have](https://github.com/NatlabRockies/R2X/labels/Optional):
-  Community contributions welcome.
-- [Ideas](https://github.com/NatlabRockies/R2X/issues?q=is%3Aopen+is%3Aissue+label%3AIdea):
-  Future directions for R2X.
+- [Active issues](https://github.com/NatlabRockies/R2X/issues?q=is%3Aopen+is%3Aissue+label%3A%22Working+on+it+%F0%9F%92%AA%22+sort%3Aupdated-asc)
+- [Prioritized backlog](https://github.com/NatlabRockies/R2X/issues?q=is%3Aopen+is%3Aissue+label%3ABacklog)
+- [Nice-to-have](https://github.com/NatlabRockies/R2X/labels/Optional)
+- [Ideas](https://github.com/NatlabRockies/R2X/issues?q=is%3Aopen+is%3Aissue+label%3AIdea)
 
 ```{toctree}
 :hidden: true
+getting_started.md
 dev_workflow.md
+architecture.md
+development.md
 CHANGELOG.md
 ```


### PR DESCRIPTION
## Summary

Refresh the R2X documentation structure following the documentation enhancement approach used by r2x-cli PR #185.

- Add a concise documentation index and getting-started path.
- Add architecture and development guidance grounded in the current package layout.
- Organize translation workflows and contributor guidance around current public APIs.
- Add explicit instructions for adding, reviewing, and maintaining translated documentation.

## Testing Strategy

- `git diff --check`
- Repository pre-commit hooks passed when the commit was created.

## Stacked PR

This is the first PR in a stack. The Astro migration follows in PR #326.
